### PR TITLE
fix: preserve selected tools when editing config

### DIFF
--- a/src/main/java/org/remus/giteabot/systemsettings/BotToolConfigurationService.java
+++ b/src/main/java/org/remus/giteabot/systemsettings/BotToolConfigurationService.java
@@ -55,6 +55,7 @@ public class BotToolConfigurationService {
         }
         configuration.setName(configuration.getName().trim());
 
+        BotToolConfiguration target = configuration;
         if (configuration.getId() != null) {
             BotToolConfiguration existing = configurationRepository.findById(configuration.getId())
                     .orElseThrow(() -> new IllegalArgumentException("Tool configuration not found"));
@@ -62,9 +63,10 @@ public class BotToolConfigurationService {
                 if (!existing.getName().equals(configuration.getName())) {
                     throw new IllegalArgumentException("The default tool configuration cannot be renamed");
                 }
-                // Cannot revoke the default flag through normal updates.
-                configuration.setDefaultEntry(true);
             }
+            existing.setName(configuration.getName());
+            // Preserve the managed entity and its selectedTools collection.
+            target = existing;
         } else {
             // New configurations are never default; the default is bootstrapped once.
             configuration.setDefaultEntry(false);
@@ -76,7 +78,7 @@ public class BotToolConfigurationService {
         if (duplicateName) {
             throw new IllegalArgumentException("A tool configuration with this name already exists");
         }
-        return configurationRepository.save(configuration);
+        return configurationRepository.save(target);
     }
 
     /**
@@ -128,6 +130,5 @@ public class BotToolConfigurationService {
         return candidate;
     }
 }
-
 
 

--- a/src/test/java/org/remus/giteabot/systemsettings/BotToolConfigurationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/systemsettings/BotToolConfigurationServiceTest.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -127,6 +128,34 @@ class BotToolConfigurationServiceTest {
     }
 
     @Test
+    void save_existingConfiguration_preservesSelectedTools() {
+        BotToolConfiguration persisted = new BotToolConfiguration();
+        persisted.setId(2L);
+        persisted.setName("Java");
+        persisted.setDefaultEntry(false);
+        BotToolSelection selectedTool = new BotToolSelection();
+        selectedTool.setConfiguration(persisted);
+        selectedTool.setToolName("mvn");
+        selectedTool.setToolKind("VALIDATION");
+        persisted.setSelectedTools(List.of(selectedTool));
+
+        BotToolConfiguration update = new BotToolConfiguration();
+        update.setId(2L);
+        update.setName("  Java Renamed  ");
+
+        when(configurationRepository.findById(2L)).thenReturn(Optional.of(persisted));
+        when(configurationRepository.existsByNameAndIdNot("Java Renamed", 2L)).thenReturn(false);
+        when(configurationRepository.save(any(BotToolConfiguration.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        BotToolConfiguration saved = service.save(update);
+
+        assertSame(persisted, saved);
+        assertEquals("Java Renamed", saved.getName());
+        assertEquals(List.of(selectedTool), saved.getSelectedTools());
+    }
+
+    @Test
     void deleteById_defaultConfiguration_throws() {
         BotToolConfiguration persisted = new BotToolConfiguration();
         persisted.setId(1L);
@@ -234,6 +263,5 @@ class BotToolConfigurationServiceTest {
         assertEquals("Custom", captor.getValue().getName());
     }
 }
-
 
 


### PR DESCRIPTION
Fixes #144.

Editing a tool configuration submits a form-bound configuration object without its selected tools. Saving that object directly can replace the managed entity collection and clear the existing selections.

This updates existing configurations through the managed entity returned by the repository, preserving the `selectedTools` collection while still trimming and validating the edited name.

Tests run with Java 21:
- `mvn -Dmaven.repo.local=/tmp/ai-git-bot-144-m2 -Dtest=BotToolConfigurationServiceTest#save_existingConfiguration_preservesSelectedTools test`
- `mvn -Dmaven.repo.local=/tmp/ai-git-bot-144-m2 clean test`
- `git diff --check`
