### PR TITLE
fix: add dark mode toggle and structural dark theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Added
 
+- Added Dark Theme support with a toggle switch in the navbar.
 - Added repository discovery metadata for search engines, LLMs, autonomous agents, and RAG systems.
 - Added `llms.txt` as a concise LLM entry point.
 - Added `llms-full.txt` as an expanded single-file project reference for larger context windows.

--- a/src/main/resources/static/js/theme-init.js
+++ b/src/main/resources/static/js/theme-init.js
@@ -1,0 +1,98 @@
+(function() {
+    const getStoredTheme = () => {
+        try {
+            return localStorage.getItem('theme');
+        } catch (e) {
+            return null;
+        }
+    };
+
+    const setStoredTheme = theme => {
+        try {
+            if (theme === 'auto') {
+                localStorage.removeItem('theme');
+            } else {
+                localStorage.setItem('theme', theme);
+            }
+        } catch (e) {}
+    };
+
+    const getPreferredTheme = () => {
+        const storedTheme = getStoredTheme();
+        if (storedTheme) {
+            return storedTheme;
+        }
+        return 'auto';
+    };
+
+    const setTheme = theme => {
+        let actualTheme = theme;
+        if (theme === 'auto') {
+            actualTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            document.documentElement.style.colorScheme = 'light dark';
+        } else {
+            document.documentElement.style.colorScheme = theme;
+        }
+        document.documentElement.setAttribute('data-bs-theme', actualTheme);
+        updateUI(theme, actualTheme);
+    };
+
+    const updateUI = (theme, actualTheme) => {
+        // Update icons and buttons if they exist
+        const themeIcon = document.getElementById('theme-icon');
+        const themeToggle = document.getElementById('bd-theme');
+
+        if (themeIcon) {
+            if (actualTheme === 'dark') {
+                themeIcon.classList.remove('bi-sun-fill');
+                themeIcon.classList.add('bi-moon-stars-fill');
+            } else {
+                themeIcon.classList.remove('bi-moon-stars-fill');
+                themeIcon.classList.add('bi-sun-fill');
+            }
+        }
+
+        if (themeToggle) {
+            themeToggle.setAttribute('aria-pressed', actualTheme === 'dark');
+        }
+    };
+
+    // Initialize theme immediately to prevent flash
+    setTheme(getPreferredTheme());
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+        const storedTheme = getStoredTheme();
+        if (!storedTheme) {
+            setTheme('auto');
+        }
+    });
+
+    // Expose toggle function globally
+    window.toggleTheme = () => {
+        const currentTheme = getPreferredTheme();
+        let newTheme;
+        // Cycle: auto -> dark -> light -> auto
+        if (currentTheme === 'auto') {
+            newTheme = 'dark';
+        } else if (currentTheme === 'dark') {
+            newTheme = 'light';
+        } else {
+            newTheme = 'auto';
+        }
+        setStoredTheme(newTheme);
+        setTheme(newTheme);
+    };
+
+    // When DOM is loaded, update UI again to catch any elements that weren't ready
+    document.addEventListener('DOMContentLoaded', () => {
+        setTheme(getPreferredTheme());
+
+        const themeToggle = document.getElementById('bd-theme');
+        if (themeToggle) {
+            themeToggle.addEventListener('click', () => {
+                window.toggleTheme();
+            });
+        }
+    });
+})();

--- a/src/main/resources/templates/ai-integrations/list.html
+++ b/src/main/resources/templates/ai-integrations/list.html
@@ -15,15 +15,15 @@
         <div class="card">
             <div class="card-body">
                 <div th:if="${#lists.isEmpty(integrations)}" class="text-center py-4">
-                    <i class="bi bi-inbox fs-1 text-muted"></i>
-                    <p class="text-muted mt-2">No AI integrations configured yet.</p>
+                    <i class="bi bi-inbox fs-1 text-secondary"></i>
+                    <p class="text-secondary mt-2">No AI integrations configured yet.</p>
                     <a th:href="@{/ai-integrations/new}" class="btn btn-primary">
                         <i class="bi bi-plus-circle"></i> Add your first AI integration
                     </a>
                 </div>
                 <div th:if="${!#lists.isEmpty(integrations)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead>
+                        <thead class="table-group-divider">
                             <tr>
                                 <th>Name</th>
                                 <th>Provider Type</th>

--- a/src/main/resources/templates/ai-integrations/list.html
+++ b/src/main/resources/templates/ai-integrations/list.html
@@ -23,7 +23,7 @@
                 </div>
                 <div th:if="${!#lists.isEmpty(integrations)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead class="table-light">
+                        <thead>
                             <tr>
                                 <th>Name</th>
                                 <th>Provider Type</th>

--- a/src/main/resources/templates/bots/form.html
+++ b/src/main/resources/templates/bots/form.html
@@ -153,7 +153,7 @@
                         </div>
 
                         <div class="col-12">
-                            <label for="deploymentTargetId" class="form-label">Deployment Target <span class="text-muted">(optional)</span></label>
+                            <label for="deploymentTargetId" class="form-label">Deployment Target <span class="text-secondary">(optional)</span></label>
                             <select class="form-select" id="deploymentTargetId" name="deploymentTargetId">
                                 <option value="">(none — preview-aware workflows will be skipped)</option>
                                 <option th:each="deploymentTarget : ${deploymentTargets}"
@@ -206,12 +206,18 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <h6>Review System-Prompt</h6>
-                        <div class="border rounded p-3 mb-4 bg-light" id="reviewPromptPreview"></div>
-                        <h6>Issue-Agent System-Prompt</h6>
-                        <div class="border rounded p-3 mb-4 bg-light" id="agentPromptPreview"></div>
-                        <h6>Writer-Agent System-Prompt</h6>
-                        <div class="border rounded p-3 bg-light" id="writerPromptPreview"></div>
+                        <div class="mb-4">
+                            <h6>Review System-Prompt</h6>
+                            <div class="border rounded p-3 bg-body-tertiary text-body" id="reviewPromptPreview"></div>
+                        </div>
+                        <div class="mb-4">
+                            <h6>Issue-Agent System-Prompt</h6>
+                            <div class="border rounded p-3 bg-body-tertiary text-body" id="agentPromptPreview"></div>
+                        </div>
+                        <div>
+                            <h6>Writer-Agent System-Prompt</h6>
+                            <div class="border rounded p-3 bg-body-tertiary text-body" id="writerPromptPreview"></div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -337,7 +343,7 @@
                             .replace(/'/g, '&#39;');
                     }
                     if (!tools || tools.length === 0) {
-                        return '<p class="text-muted mb-0">No selected MCP tools.</p>';
+                        return '<p class="text-secondary mb-0">No selected MCP tools.</p>';
                     }
                     const rows = tools.map(function(tool) {
                         const title = tool.title && tool.title.trim() ? escapeHtml(tool.title) : '-';
@@ -350,7 +356,7 @@
                             + '</tr>';
                     }).join('');
                     return '<div class="table-responsive"><table class="table table-sm table-hover align-middle mb-0">'
-                        + '<thead class="table-light"><tr><th>Server</th><th>Tool</th><th>Title</th><th>Description</th></tr></thead>'
+                        + '<thead class="table-group-divider"><tr><th>Server</th><th>Tool</th><th>Title</th><th>Description</th></tr></thead>'
                         + '<tbody>' + rows + '</tbody></table></div>';
                 }
 
@@ -398,7 +404,7 @@
                             .replace(/'/g, '&#39;');
                     }
                     if (!tools || tools.length === 0) {
-                        return '<p class="text-muted mb-0">No built-in tools enabled for this configuration.</p>';
+                        return '<p class="text-secondary mb-0">No built-in tools enabled for this configuration.</p>';
                     }
                     const rows = tools.map(function(tool) {
                         const description = tool.description && tool.description.trim() ? escapeHtml(tool.description) : '-';
@@ -458,7 +464,7 @@
 
                 function renderWorkflowTable(rows) {
                     if (!rows || rows.length === 0) {
-                        return '<p class="text-muted mb-0">No workflows enabled for this configuration.</p>';
+                        return '<p class="text-secondary mb-0">No workflows enabled for this configuration.</p>';
                     }
                     const body = rows.map(function(row) {
                         let paramsCell = '-';
@@ -476,7 +482,7 @@
                             + '</tr>';
                     }).join('');
                     return '<div class="table-responsive"><table class="table table-sm table-hover align-middle mb-0">'
-                        + '<thead class="table-light"><tr><th>Category</th><th>Key</th><th>Name</th><th>Params</th></tr></thead>'
+                        + '<thead class="table-group-divider"><tr><th>Category</th><th>Key</th><th>Name</th><th>Params</th></tr></thead>'
                         + '<tbody>' + body + '</tbody></table></div>';
                 }
 

--- a/src/main/resources/templates/bots/list.html
+++ b/src/main/resources/templates/bots/list.html
@@ -15,15 +15,15 @@
         <div class="card">
             <div class="card-body">
                 <div th:if="${#lists.isEmpty(bots)}" class="text-center py-4">
-                    <i class="bi bi-inbox fs-1 text-muted"></i>
-                    <p class="text-muted mt-2">No bots configured yet.</p>
+                    <i class="bi bi-inbox fs-1 text-secondary"></i>
+                    <p class="text-secondary mt-2">No bots configured yet.</p>
                     <a th:href="@{/bots/new}" class="btn btn-primary">
                         <i class="bi bi-plus-circle"></i> Create your first bot
                     </a>
                 </div>
                 <div th:if="${!#lists.isEmpty(bots)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead>
+                        <thead class="table-group-divider">
                             <tr>
                                 <th>Name</th>
                                 <th>Username</th>
@@ -63,7 +63,7 @@
                                             <i class="bi bi-clipboard"></i>
                                         </button>
                                     </span>
-                                    <span th:if="${bot.webhookPath == null}" class="text-muted">Not set</span>
+                                    <span th:if="${bot.webhookPath == null}" class="text-secondary">Not set</span>
                                 </td>
                                 <td>
                                     <div class="btn-group-with-gap btn-group-sm">

--- a/src/main/resources/templates/bots/list.html
+++ b/src/main/resources/templates/bots/list.html
@@ -23,7 +23,7 @@
                 </div>
                 <div th:if="${!#lists.isEmpty(bots)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead class="table-light">
+                        <thead>
                             <tr>
                                 <th>Name</th>
                                 <th>Username</th>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -103,7 +103,7 @@
                 </div>
                 <div th:if="${!#lists.isEmpty(bots)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead class="table-light">
+                        <thead>
                             <tr>
                                 <th>Name</th>
                                 <th>Username</th>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -95,15 +95,15 @@
             </div>
             <div class="card-body">
                 <div th:if="${#lists.isEmpty(bots)}" class="text-center py-4">
-                    <i class="bi bi-inbox fs-1 text-muted"></i>
-                    <p class="text-muted mt-2">No bots configured yet.</p>
+                    <i class="bi bi-inbox fs-1 text-secondary"></i>
+                    <p class="text-secondary mt-2">No bots configured yet.</p>
                     <a th:href="@{/bots/new}" class="btn btn-primary">
                         <i class="bi bi-plus-circle"></i> Create your first bot
                     </a>
                 </div>
                 <div th:if="${!#lists.isEmpty(bots)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead>
+                        <thead class="table-group-divider">
                             <tr>
                                 <th>Name</th>
                                 <th>Username</th>
@@ -130,7 +130,7 @@
                                 <td>
                                     <span th:if="${bot.lastWebhookAt != null}"
                                           th:text="${#temporals.format(bot.lastWebhookAt, 'yyyy-MM-dd HH:mm')}"></span>
-                                    <span th:if="${bot.lastWebhookAt == null}" class="text-muted">Never</span>
+                                    <span th:if="${bot.lastWebhookAt == null}" class="text-secondary">Never</span>
                                 </td>
                                 <td>
                                     <span th:if="${bot.lastErrorMessage != null}"
@@ -141,7 +141,7 @@
                                         <span th:if="${bot.lastErrorAt != null}"
                                               th:text="${#temporals.format(bot.lastErrorAt, 'yyyy-MM-dd HH:mm')}"></span>
                                     </span>
-                                    <span th:if="${bot.lastErrorMessage == null}" class="text-muted">None</span>
+                                    <span th:if="${bot.lastErrorMessage == null}" class="text-secondary">None</span>
                                 </td>
                                 <td>
                                     <a th:href="@{/bots/{id}/edit(id=${bot.id})}" class="btn btn-sm btn-outline-primary">

--- a/src/main/resources/templates/git-integrations/list.html
+++ b/src/main/resources/templates/git-integrations/list.html
@@ -23,7 +23,7 @@
                 </div>
                 <div th:if="${!#lists.isEmpty(integrations)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead class="table-light">
+                        <thead>
                             <tr>
                                 <th>Name</th>
                                 <th>Provider Type</th>

--- a/src/main/resources/templates/git-integrations/list.html
+++ b/src/main/resources/templates/git-integrations/list.html
@@ -15,15 +15,15 @@
         <div class="card">
             <div class="card-body">
                 <div th:if="${#lists.isEmpty(integrations)}" class="text-center py-4">
-                    <i class="bi bi-inbox fs-1 text-muted"></i>
-                    <p class="text-muted mt-2">No Git integrations configured yet.</p>
+                    <i class="bi bi-inbox fs-1 text-secondary"></i>
+                    <p class="text-secondary mt-2">No Git integrations configured yet.</p>
                     <a th:href="@{/git-integrations/new}" class="btn btn-primary">
                         <i class="bi bi-plus-circle"></i> Add your first Git integration
                     </a>
                 </div>
                 <div th:if="${!#lists.isEmpty(integrations)}" class="table-responsive">
                     <table class="table table-hover align-middle mb-0">
-                        <thead>
+                        <thead class="table-group-divider">
                             <tr>
                                 <th>Name</th>
                                 <th>Provider Type</th>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -8,36 +8,17 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
-    <script>
-        (function() {
-            const getStoredTheme = () => {
-                try {
-                    return localStorage.getItem('theme');
-                } catch (e) {
-                    return null;
-                }
-            };
-            const getPreferredTheme = () => {
-                const storedTheme = getStoredTheme();
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            };
-            const setTheme = theme => {
-                document.documentElement.setAttribute('data-bs-theme', theme);
-            };
-            setTheme(getPreferredTheme());
-        })();
-    </script>
+    <script th:src="@{/js/theme-init.js}"></script>
 </head>
 <body>
 
 <!-- Layout fragment -->
 <div th:fragment="layout(title, content)">
-    <div th:replace="~{layout :: head(${title})}"></div>
+    <th:block th:replace="~{layout :: head(${title})}"></th:block>
 
-    <nav class="navbar navbar-expand-lg border-bottom shadow-sm mb-4" data-bs-theme="dark" style="background-color: #212529;">
+    <nav class="navbar navbar-expand-lg border-bottom shadow-sm mb-4" 
+         style="background-color: light-dark(#212529, #1a1d20); border-color: light-dark(#dee2e6, #343a40) !important;"
+         data-bs-theme="dark">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" th:href="@{/dashboard}">
                 <img th:src="@{/images/favicon.svg}" alt="AI Git Bot logo" width="28" height="28" class="me-2 brand-icon"/>
@@ -114,73 +95,6 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script>
-        (function() {
-            const themeToggle = document.getElementById('bd-theme');
-            const themeIcon = document.getElementById('theme-icon');
-
-            const getStoredTheme = () => {
-                try {
-                    return localStorage.getItem('theme');
-                } catch (e) {
-                    return null;
-                }
-            };
-
-            const setStoredTheme = theme => {
-                try {
-                    localStorage.setItem('theme', theme);
-                } catch (e) {}
-            };
-
-            const getPreferredTheme = () => {
-                const storedTheme = getStoredTheme();
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            };
-
-            const setTheme = theme => {
-                document.documentElement.setAttribute('data-bs-theme', theme);
-                updateThemeIcon(theme);
-                if (themeToggle) {
-                    themeToggle.setAttribute('aria-pressed', theme === 'dark');
-                }
-            };
-
-            function updateThemeIcon(theme) {
-                if (!themeIcon) return;
-                if (theme === 'dark') {
-                    themeIcon.classList.remove('bi-sun-fill');
-                    themeIcon.classList.add('bi-moon-stars-fill');
-                } else {
-                    themeIcon.classList.remove('bi-moon-stars-fill');
-                    themeIcon.classList.add('bi-sun-fill');
-                }
-            }
-
-            if (themeToggle) {
-                themeToggle.addEventListener('click', () => {
-                    const currentTheme = document.documentElement.getAttribute('data-bs-theme');
-                    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-                    setTheme(newTheme);
-                    setStoredTheme(newTheme);
-                });
-            }
-
-            // Listen for system theme changes
-            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-                const storedTheme = getStoredTheme();
-                if (!storedTheme) {
-                    setTheme(getPreferredTheme());
-                }
-            });
-
-            // Initialize on load
-            setTheme(getPreferredTheme());
-        })();
-    </script>
 </div>
 
 </body>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -8,6 +8,22 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
+    <script>
+        (function() {
+            const getStoredTheme = () => localStorage.getItem('theme');
+            const getPreferredTheme = () => {
+                const storedTheme = getStoredTheme();
+                if (storedTheme) {
+                    return storedTheme;
+                }
+                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            };
+            const setTheme = theme => {
+                document.documentElement.setAttribute('data-bs-theme', theme);
+            };
+            setTheme(getPreferredTheme());
+        })();
+    </script>
 </head>
 <body>
 
@@ -15,7 +31,7 @@
 <div th:fragment="layout(title, content)">
     <div th:replace="~{layout :: head(${title})}"></div>
 
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <nav class="navbar navbar-expand-lg border-bottom shadow-sm mb-4 theme-aware-navbar">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" th:href="@{/dashboard}">
                 <img th:src="@{/images/favicon.svg}" alt="AI Git Bot logo" width="28" height="28" class="me-2 brand-icon"/>
@@ -59,10 +75,15 @@
                         </a>
                     </li>
                 </ul>
-                <ul class="navbar-nav">
+                <ul class="navbar-nav align-items-center">
+                    <li class="nav-item me-2">
+                        <button class="btn btn-link nav-link px-2" id="bd-theme" type="button" aria-expanded="false" title="Toggle theme">
+                            <i class="bi bi-sun-fill theme-icon-active" id="theme-icon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item">
                         <form th:action="@{/logout}" method="post" class="d-inline">
-                            <button type="submit" class="btn btn-outline-light btn-sm">
+                            <button type="submit" class="btn btn-outline-primary btn-sm">
                                 <i class="bi bi-box-arrow-right"></i> Logout
                             </button>
                         </form>
@@ -87,6 +108,34 @@
     </main>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        document.getElementById('bd-theme').addEventListener('click', () => {
+            const currentTheme = document.documentElement.getAttribute('data-bs-theme');
+            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+            
+            document.documentElement.setAttribute('data-bs-theme', newTheme);
+            localStorage.setItem('theme', newTheme);
+            updateThemeIcon(newTheme);
+        });
+
+        function updateThemeIcon(theme) {
+            const icon = document.getElementById('theme-icon');
+            if (theme === 'dark') {
+                icon.classList.remove('bi-sun-fill');
+                icon.classList.add('bi-moon-stars-fill');
+            } else {
+                icon.classList.remove('bi-moon-stars-fill');
+                icon.classList.add('bi-sun-fill');
+            }
+        }
+
+        // Initialize icon on load
+        (function() {
+            const theme = document.documentElement.getAttribute('data-bs-theme') || 
+                         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+            updateThemeIcon(theme);
+        })();
+    </script>
 </div>
 
 </body>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -10,7 +10,13 @@
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
     <script>
         (function() {
-            const getStoredTheme = () => localStorage.getItem('theme');
+            const getStoredTheme = () => {
+                try {
+                    return localStorage.getItem('theme');
+                } catch (e) {
+                    return null;
+                }
+            };
             const getPreferredTheme = () => {
                 const storedTheme = getStoredTheme();
                 if (storedTheme) {
@@ -31,7 +37,7 @@
 <div th:fragment="layout(title, content)">
     <div th:replace="~{layout :: head(${title})}"></div>
 
-    <nav class="navbar navbar-expand-lg border-bottom shadow-sm mb-4 theme-aware-navbar">
+    <nav class="navbar navbar-expand-lg border-bottom shadow-sm mb-4" data-bs-theme="dark" style="background-color: #212529;">
         <div class="container">
             <a class="navbar-brand d-flex align-items-center" th:href="@{/dashboard}">
                 <img th:src="@{/images/favicon.svg}" alt="AI Git Bot logo" width="28" height="28" class="me-2 brand-icon"/>
@@ -77,13 +83,13 @@
                 </ul>
                 <ul class="navbar-nav align-items-center">
                     <li class="nav-item me-2">
-                        <button class="btn btn-link nav-link px-2" id="bd-theme" type="button" aria-expanded="false" title="Toggle theme">
-                            <i class="bi bi-sun-fill theme-icon-active" id="theme-icon"></i>
+                        <button class="btn btn-link nav-link px-2" id="bd-theme" type="button" aria-expanded="false" title="Toggle theme" aria-label="Toggle color theme">
+                            <i class="bi bi-sun-fill" id="theme-icon"></i>
                         </button>
                     </li>
                     <li class="nav-item">
                         <form th:action="@{/logout}" method="post" class="d-inline">
-                            <button type="submit" class="btn btn-outline-primary btn-sm">
+                            <button type="submit" class="btn btn-outline-light btn-sm">
                                 <i class="bi bi-box-arrow-right"></i> Logout
                             </button>
                         </form>
@@ -109,31 +115,70 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        document.getElementById('bd-theme').addEventListener('click', () => {
-            const currentTheme = document.documentElement.getAttribute('data-bs-theme');
-            const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-            
-            document.documentElement.setAttribute('data-bs-theme', newTheme);
-            localStorage.setItem('theme', newTheme);
-            updateThemeIcon(newTheme);
-        });
-
-        function updateThemeIcon(theme) {
-            const icon = document.getElementById('theme-icon');
-            if (theme === 'dark') {
-                icon.classList.remove('bi-sun-fill');
-                icon.classList.add('bi-moon-stars-fill');
-            } else {
-                icon.classList.remove('bi-moon-stars-fill');
-                icon.classList.add('bi-sun-fill');
-            }
-        }
-
-        // Initialize icon on load
         (function() {
-            const theme = document.documentElement.getAttribute('data-bs-theme') || 
-                         (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-            updateThemeIcon(theme);
+            const themeToggle = document.getElementById('bd-theme');
+            const themeIcon = document.getElementById('theme-icon');
+
+            const getStoredTheme = () => {
+                try {
+                    return localStorage.getItem('theme');
+                } catch (e) {
+                    return null;
+                }
+            };
+
+            const setStoredTheme = theme => {
+                try {
+                    localStorage.setItem('theme', theme);
+                } catch (e) {}
+            };
+
+            const getPreferredTheme = () => {
+                const storedTheme = getStoredTheme();
+                if (storedTheme) {
+                    return storedTheme;
+                }
+                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            };
+
+            const setTheme = theme => {
+                document.documentElement.setAttribute('data-bs-theme', theme);
+                updateThemeIcon(theme);
+                if (themeToggle) {
+                    themeToggle.setAttribute('aria-pressed', theme === 'dark');
+                }
+            };
+
+            function updateThemeIcon(theme) {
+                if (!themeIcon) return;
+                if (theme === 'dark') {
+                    themeIcon.classList.remove('bi-sun-fill');
+                    themeIcon.classList.add('bi-moon-stars-fill');
+                } else {
+                    themeIcon.classList.remove('bi-moon-stars-fill');
+                    themeIcon.classList.add('bi-sun-fill');
+                }
+            }
+
+            if (themeToggle) {
+                themeToggle.addEventListener('click', () => {
+                    const currentTheme = document.documentElement.getAttribute('data-bs-theme');
+                    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                    setTheme(newTheme);
+                    setStoredTheme(newTheme);
+                });
+            }
+
+            // Listen for system theme changes
+            window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+                const storedTheme = getStoredTheme();
+                if (!storedTheme) {
+                    setTheme(getPreferredTheme());
+                }
+            });
+
+            // Initialize on load
+            setTheme(getPreferredTheme());
         })();
     </script>
 </div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,8 +7,30 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
+    <script>
+        (function() {
+            const getStoredTheme = () => {
+                try {
+                    return localStorage.getItem('theme');
+                } catch (e) {
+                    return null;
+                }
+            };
+            const getPreferredTheme = () => {
+                const storedTheme = getStoredTheme();
+                if (storedTheme) {
+                    return storedTheme;
+                }
+                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            };
+            const setTheme = theme => {
+                document.documentElement.setAttribute('data-bs-theme', theme);
+            };
+            setTheme(getPreferredTheme());
+        })();
+    </script>
 </head>
-<body class="bg-light">
+<body class="bg-body-tertiary">
     <div class="container d-flex align-items-center justify-content-center" style="min-height: 100vh;">
         <div class="col-md-6 col-lg-5">
             <div class="card shadow">
@@ -16,7 +38,7 @@
                     <div class="text-center mb-4">
                         <img th:src="@{/images/favicon.svg}" alt="AI Git Bot logo" width="64" height="64" class="mb-2 brand-icon"/>
                         <h3 class="mt-2">AI Git Bot</h3>
-                        <p class="text-muted">Sign in to manage your bots</p>
+                        <p class="text-secondary">Sign in to manage your bots</p>
                     </div>
 
                     <div th:if="${param.error}" class="alert alert-danger" role="alert">

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -7,28 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
-    <script>
-        (function() {
-            const getStoredTheme = () => {
-                try {
-                    return localStorage.getItem('theme');
-                } catch (e) {
-                    return null;
-                }
-            };
-            const getPreferredTheme = () => {
-                const storedTheme = getStoredTheme();
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            };
-            const setTheme = theme => {
-                document.documentElement.setAttribute('data-bs-theme', theme);
-            };
-            setTheme(getPreferredTheme());
-        })();
-    </script>
+    <script th:src="@{/js/theme-init.js}"></script>
 </head>
 <body class="bg-body-tertiary">
     <div class="container d-flex align-items-center justify-content-center" style="min-height: 100vh;">

--- a/src/main/resources/templates/setup.html
+++ b/src/main/resources/templates/setup.html
@@ -7,28 +7,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
-    <script>
-        (function() {
-            const getStoredTheme = () => {
-                try {
-                    return localStorage.getItem('theme');
-                } catch (e) {
-                    return null;
-                }
-            };
-            const getPreferredTheme = () => {
-                const storedTheme = getStoredTheme();
-                if (storedTheme) {
-                    return storedTheme;
-                }
-                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-            };
-            const setTheme = theme => {
-                document.documentElement.setAttribute('data-bs-theme', theme);
-            };
-            setTheme(getPreferredTheme());
-        })();
-    </script>
+    <script th:src="@{/js/theme-init.js}"></script>
 </head>
 <body class="bg-body-tertiary">
     <div class="container d-flex align-items-center justify-content-center" style="min-height: 100vh;">

--- a/src/main/resources/templates/setup.html
+++ b/src/main/resources/templates/setup.html
@@ -7,8 +7,30 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/svg+xml" th:href="@{/images/favicon.svg}"/>
+    <script>
+        (function() {
+            const getStoredTheme = () => {
+                try {
+                    return localStorage.getItem('theme');
+                } catch (e) {
+                    return null;
+                }
+            };
+            const getPreferredTheme = () => {
+                const storedTheme = getStoredTheme();
+                if (storedTheme) {
+                    return storedTheme;
+                }
+                return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            };
+            const setTheme = theme => {
+                document.documentElement.setAttribute('data-bs-theme', theme);
+            };
+            setTheme(getPreferredTheme());
+        })();
+    </script>
 </head>
-<body class="bg-light">
+<body class="bg-body-tertiary">
     <div class="container d-flex align-items-center justify-content-center" style="min-height: 100vh;">
         <div class="col-md-6 col-lg-5">
             <div class="card shadow">
@@ -16,7 +38,7 @@
                     <div class="text-center mb-4">
                         <img th:src="@{/images/favicon.svg}" alt="AI Git Bot logo" width="64" height="64" class="mb-2 brand-icon"/>
                         <h3 class="mt-2">Welcome to AI Git Bot</h3>
-                        <p class="text-muted">Create your administrator account</p>
+                        <p class="text-secondary">Create your administrator account</p>
                     </div>
 
                     <div th:if="${error}" class="alert alert-danger" role="alert">

--- a/src/main/resources/templates/system-settings/bot-tools-selection.html
+++ b/src/main/resources/templates/system-settings/bot-tools-selection.html
@@ -15,7 +15,7 @@
                     Configuration: <strong th:text="${botToolConfiguration.name}"></strong>
                     <span th:if="${botToolConfiguration.defaultEntry}" class="badge bg-primary ms-2">Default</span>
                 </p>
-                <p class="text-muted mb-4">
+                <p class="text-secondary mb-4">
                     Whitelist of built-in agent tools (file, context, validation, repository) that bots assigned
                     to this configuration may expose to the AI. Disabled tools are excluded from both native
                     tool calling and legacy prompt-based tool instructions, and any attempt to invoke them at
@@ -51,13 +51,13 @@
                     </div>
                     <div class="col-md-2">
                         <label class="form-label">Selected</label>
-                        <div class="form-control bg-light" id="selectedCount">0</div>
+                        <div class="form-control bg-body-tertiary" id="selectedCount">0</div>
                     </div>
                 </div>
 
                 <div class="table-responsive">
                     <table class="table table-hover align-middle mb-2">
-                        <thead class="table-light">
+                        <thead class="table-group-divider">
                         <tr>
                             <th style="width: 48px;">
                                 <input id="selectAllVisible" type="checkbox" class="form-check-input"
@@ -78,7 +78,7 @@
                 </div>
 
                 <div class="d-flex justify-content-between align-items-center mb-3">
-                    <div class="text-muted" id="paginationInfo"></div>
+                    <div class="text-secondary" id="paginationInfo"></div>
                     <div class="btn-group">
                         <button type="button" id="prevPage" class="btn btn-outline-secondary btn-sm">Previous</button>
                         <button type="button" id="nextPage" class="btn btn-outline-secondary btn-sm">Next</button>
@@ -205,7 +205,7 @@
                         const tr = document.createElement('tr');
                         const td = document.createElement('td');
                         td.colSpan = 4;
-                        td.className = 'text-center text-muted py-4';
+                        td.className = 'text-center text-secondary py-4';
                         td.textContent = 'No tools found for current filter.';
                         tr.appendChild(td);
                         rowsBody.appendChild(tr);
@@ -214,7 +214,7 @@
                         page.rows.forEach(tool => {
                             if (sortField === 'toolKind' && tool.toolKind !== previousKind) {
                                 const groupTr = document.createElement('tr');
-                                groupTr.className = 'table-light';
+                                groupTr.className = 'table-group-divider border-top-0';
                                 const groupTd = document.createElement('td');
                                 groupTd.colSpan = 4;
                                 const strong = document.createElement('strong');

--- a/src/main/resources/templates/system-settings/list.html
+++ b/src/main/resources/templates/system-settings/list.html
@@ -28,7 +28,7 @@
                         </div>
                         <div th:if="${!#lists.isEmpty(systemPrompts)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead class="table-light">
+                                <thead>
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -92,7 +92,7 @@
                         </div>
                         <div th:if="${!#lists.isEmpty(mcpConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead class="table-light">
+                                <thead>
                                 <tr>
                                     <th>Name</th>
                                     <th>Updated</th>
@@ -151,7 +151,7 @@
                         </div>
                         <div th:if="${!#lists.isEmpty(botToolConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead class="table-light">
+                                <thead>
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -219,7 +219,7 @@
                         </div>
                         <div th:if="${!#lists.isEmpty(workflowConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead class="table-light">
+                                <thead>
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -287,7 +287,7 @@
                         </div>
                         <div th:if="${!#lists.isEmpty(deploymentTargets)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead class="table-light">
+                                <thead>
                                 <tr>
                                     <th>Name</th>
                                     <th>Strategy</th>

--- a/src/main/resources/templates/system-settings/list.html
+++ b/src/main/resources/templates/system-settings/list.html
@@ -15,7 +15,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>
                             <h5 class="mb-0">System prompts</h5>
-                            <small class="text-muted">Prompt sets available to bot configurations.</small>
+                            <small class="text-secondary">Prompt sets available to bot configurations.</small>
                         </div>
                         <a th:href="@{/system-settings/system-prompts/new}" class="btn btn-primary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add
@@ -23,12 +23,12 @@
                     </div>
                     <div class="card-body">
                         <div th:if="${#lists.isEmpty(systemPrompts)}" class="text-center py-4">
-                            <i class="bi bi-inbox fs-1 text-muted"></i>
-                            <p class="text-muted mt-2">No system prompts configured yet.</p>
+                            <i class="bi bi-inbox fs-1 text-secondary"></i>
+                            <p class="text-secondary mt-2">No system prompts configured yet.</p>
                         </div>
                         <div th:if="${!#lists.isEmpty(systemPrompts)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead>
+                                <thead class="table-group-divider">
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -79,7 +79,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>
                             <h5 class="mb-0">MCP configurations</h5>
-                            <small class="text-muted">Remote MCP server configurations assignable to bots.</small>
+                            <small class="text-secondary">Remote MCP server configurations assignable to bots.</small>
                         </div>
                         <a th:href="@{/system-settings/mcp-configurations/new}" class="btn btn-primary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add
@@ -87,12 +87,12 @@
                     </div>
                     <div class="card-body">
                         <div th:if="${#lists.isEmpty(mcpConfigurations)}" class="text-center py-4">
-                            <i class="bi bi-inbox fs-1 text-muted"></i>
-                            <p class="text-muted mt-2">No MCP configurations configured yet.</p>
+                            <i class="bi bi-inbox fs-1 text-secondary"></i>
+                            <p class="text-secondary mt-2">No MCP configurations configured yet.</p>
                         </div>
                         <div th:if="${!#lists.isEmpty(mcpConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead>
+                                <thead class="table-group-divider">
                                 <tr>
                                     <th>Name</th>
                                     <th>Updated</th>
@@ -138,7 +138,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>
                             <h5 class="mb-0">Tool configurations</h5>
-                            <small class="text-muted">Whitelists of built-in agent tools (file, context, validation, repository) assignable to bots.</small>
+                            <small class="text-secondary">Whitelists of built-in agent tools (file, context, validation, repository) assignable to bots.</small>
                         </div>
                         <a th:href="@{/system-settings/bot-tools/new}" class="btn btn-primary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add
@@ -146,12 +146,12 @@
                     </div>
                     <div class="card-body">
                         <div th:if="${#lists.isEmpty(botToolConfigurations)}" class="text-center py-4">
-                            <i class="bi bi-inbox fs-1 text-muted"></i>
-                            <p class="text-muted mt-2">No tool configurations yet.</p>
+                            <i class="bi bi-inbox fs-1 text-secondary"></i>
+                            <p class="text-secondary mt-2">No tool configurations yet.</p>
                         </div>
                         <div th:if="${!#lists.isEmpty(botToolConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead>
+                                <thead class="table-group-divider">
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -206,7 +206,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>
                             <h5 class="mb-0">Workflow configurations</h5>
-                            <small class="text-muted">Named whitelists of PR workflows (review, tests, …) assignable to bots.</small>
+                            <small class="text-secondary">Named whitelists of PR workflows (review, tests, …) assignable to bots.</small>
                         </div>
                         <a th:href="@{/system-settings/workflow-configurations/new}" class="btn btn-primary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add
@@ -214,12 +214,12 @@
                     </div>
                     <div class="card-body">
                         <div th:if="${#lists.isEmpty(workflowConfigurations)}" class="text-center py-4">
-                            <i class="bi bi-inbox fs-1 text-muted"></i>
-                            <p class="text-muted mt-2">No workflow configurations yet.</p>
+                            <i class="bi bi-inbox fs-1 text-secondary"></i>
+                            <p class="text-secondary mt-2">No workflow configurations yet.</p>
                         </div>
                         <div th:if="${!#lists.isEmpty(workflowConfigurations)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead>
+                                <thead class="table-group-divider">
                                 <tr>
                                     <th>Name</th>
                                     <th>Default</th>
@@ -274,7 +274,7 @@
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <div>
                             <h5 class="mb-0">Deployment targets</h5>
-                            <small class="text-muted">Per-PR preview environments used by workflows that need a live deployment (E2E tests, smoke checks).</small>
+                            <small class="text-secondary">Per-PR preview environments used by workflows that need a live deployment (E2E tests, smoke checks).</small>
                         </div>
                         <a th:href="@{/system-settings/deployment-targets/new}" class="btn btn-primary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add
@@ -282,12 +282,12 @@
                     </div>
                     <div class="card-body">
                         <div th:if="${#lists.isEmpty(deploymentTargets)}" class="text-center py-4">
-                            <i class="bi bi-cloud-slash fs-1 text-muted"></i>
-                            <p class="text-muted mt-2">No deployment targets configured. Workflows needing a preview environment will be skipped on bots without a target.</p>
+                            <i class="bi bi-cloud-slash fs-1 text-secondary"></i>
+                            <p class="text-secondary mt-2">No deployment targets configured. Workflows needing a preview environment will be skipped on bots without a target.</p>
                         </div>
                         <div th:if="${!#lists.isEmpty(deploymentTargets)}" class="table-responsive">
                             <table class="table table-hover align-middle mb-0">
-                                <thead>
+                                <thead class="table-group-divider">
                                 <tr>
                                     <th>Name</th>
                                     <th>Strategy</th>
@@ -305,7 +305,7 @@
                                     <td>
                                         <code th:if="${deploymentTarget.previewUrlTemplate != null}"
                                               th:text="${deploymentTarget.previewUrlTemplate}"></code>
-                                        <span th:if="${deploymentTarget.previewUrlTemplate == null}" class="text-muted">—</span>
+                                        <span th:if="${deploymentTarget.previewUrlTemplate == null}" class="text-secondary">—</span>
                                     </td>
                                     <td th:text="${deploymentTarget.timeoutSeconds}"></td>
                                     <td>

--- a/src/main/resources/templates/system-settings/mcp-tool-selection.html
+++ b/src/main/resources/templates/system-settings/mcp-tool-selection.html
@@ -14,7 +14,7 @@
                 <p class="mb-2">
                     Configuration: <strong th:text="${mcpConfiguration.name}"></strong>
                 </p>
-                <p class="text-muted mb-4">
+                <p class="text-secondary mb-4">
                     Select only the tools you want to expose to prompts. Unselected tools stay hidden.
                 </p>
 
@@ -41,13 +41,13 @@
                     </div>
                     <div class="col-md-2">
                         <label class="form-label">Selected</label>
-                        <div class="form-control bg-light" id="selectedCount">0</div>
+                        <div class="form-control bg-body-tertiary" id="selectedCount">0</div>
                     </div>
                 </div>
 
                 <div class="table-responsive">
                     <table class="table table-hover align-middle mb-2">
-                        <thead class="table-light">
+                        <thead class="table-group-divider">
                         <tr>
                             <th style="width: 48px;">
                                 <input id="selectAllVisible" type="checkbox" class="form-check-input" title="Select all visible rows">
@@ -69,7 +69,7 @@
                 </div>
 
                 <div class="d-flex justify-content-between align-items-center mb-3">
-                    <div class="text-muted" id="paginationInfo"></div>
+                    <div class="text-secondary" id="paginationInfo"></div>
                     <div class="btn-group">
                         <button type="button" id="prevPage" class="btn btn-outline-secondary btn-sm">Previous</button>
                         <button type="button" id="nextPage" class="btn btn-outline-secondary btn-sm">Next</button>
@@ -192,7 +192,7 @@
                         const tr = document.createElement('tr');
                         const td = document.createElement('td');
                         td.colSpan = 5;
-                        td.className = 'text-center text-muted py-4';
+                        td.className = 'text-center text-secondary py-4';
                         td.textContent = 'No tools found for current filter.';
                         tr.appendChild(td);
                         rowsBody.appendChild(tr);
@@ -201,7 +201,7 @@
                         page.rows.forEach(tool => {
                             if (tool.serverName !== previousServer) {
                                 const groupTr = document.createElement('tr');
-                                groupTr.className = 'table-light';
+                                groupTr.className = 'table-group-divider border-top-0';
                                 const groupTd = document.createElement('td');
                                 groupTd.colSpan = 5;
                                 const strong = document.createElement('strong');

--- a/src/main/resources/templates/system-settings/workflow-configurations/workflows.html
+++ b/src/main/resources/templates/system-settings/workflow-configurations/workflows.html
@@ -16,7 +16,7 @@
 
         <div th:if="${error}" class="alert alert-danger" th:text="${error}"></div>
 
-        <p class="text-muted">
+        <p class="text-secondary">
             Tick the PR workflows that should run on every pull-request webhook for bots
             using this configuration. Workflows are executed sequentially in stable order
             (lexicographic by workflow key).
@@ -39,8 +39,8 @@
                                th:id="'wf-' + ${row.workflowKey}"/>
                         <label class="form-check-label" th:for="'wf-' + ${row.workflowKey}">
                             <strong th:text="${row.displayName}"></strong>
-                            <code class="ms-2 text-muted" th:text="${row.workflowKey}"></code>
-                            <span class="badge bg-light text-dark ms-2" th:text="${row.category}"></span>
+                            <code class="ms-2 text-secondary" th:text="${row.workflowKey}"></code>
+                            <span class="badge bg-body-tertiary text-body ms-2" th:text="${row.category}"></span>
                             <span th:if="${row.prWorkflow == null}" class="badge bg-warning ms-2">Not registered</span>
                         </label>
                     </div>


### PR DESCRIPTION
Fixes #146 

A structural dark theme switch in the navbar with persistent localStorage support. The solution utilizes Bootstrap 5’s native color modes (data-bs-theme) to ensure project-wide consistency for tables, cards, and forms.

Additionally, all list templates were refactored to remove hardcoded contrast classes, allowing the UI to adapt dynamically to the active theme without manual overrides.

Tests run with Java 21:
- mvn clean package