### PR TITLE
Add E2E tests for PR #178

### DIFF
--- a/tests/e2e/pr-178/collapse-all-hides-param-sections.spec.ts
+++ b/tests/e2e/pr-178/collapse-all-hides-param-sections.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test('Clicking Collapse all removes show class from wf-collapse-* elements', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const collapseBtn = page.locator('#collapseAllWorkflows');
+  await collapseBtn.waitFor({ state: 'visible', timeout: 10000 });
+
+  // Ensure at least one collapse target exists
+  const collapseTargets = page.locator("[id^='wf-collapse-']");
+  await expect.poll(async () => await collapseTargets.count(), { timeout: 10000 }).toBeGreaterThan(0);
+
+  await collapseBtn.click();
+
+  // Wait for Bootstrap collapse animation
+  await page.waitForTimeout(800);
+
+  // Verify none have the 'show' class
+  await expect.poll(async () => {
+    return await collapseTargets.evaluateAll((els) =>
+      els.every((el) => !el.classList.contains('show'))
+    );
+  }, { timeout: 5000 }).toBe(true);
+
+  // Cleanup: restore expanded state for idempotency
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+});

--- a/tests/e2e/pr-178/collapse-state-persists-across-reload.spec.ts
+++ b/tests/e2e/pr-178/collapse-state-persists-across-reload.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+
+test('Collapsed state of wf-collapse-* persists after reload', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+  const workflowsUrl = page.url();
+
+  const collapseBtn = page.locator('#collapseAllWorkflows');
+  await collapseBtn.waitFor({ state: 'visible', timeout: 10000 });
+
+  const collapseTargets = page.locator("[id^='wf-collapse-']");
+  await expect.poll(async () => await collapseTargets.count(), { timeout: 10000 }).toBeGreaterThan(0);
+
+  await collapseBtn.click();
+  await page.waitForTimeout(800);
+
+  // Reload the page
+  await page.goto(workflowsUrl);
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForTimeout(500);
+
+  const targetsAfter = page.locator("[id^='wf-collapse-']");
+  await expect.poll(async () => await targetsAfter.count(), { timeout: 10000 }).toBeGreaterThan(0);
+
+  await expect.poll(async () => {
+    return await targetsAfter.evaluateAll((els) =>
+      els.every((el) => !el.classList.contains('show'))
+    );
+  }, { timeout: 5000 }).toBe(true);
+
+  // Cleanup: re-expand so subsequent tests start expanded
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+});

--- a/tests/e2e/pr-178/enum-default-selection.spec.ts
+++ b/tests/e2e/pr-178/enum-default-selection.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+
+test('Exactly one framework radio is checked and its value is "playwright"', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+
+  // Find a radio group that contains a "playwright" option — that is the framework group
+  const playwrightRadio = page.locator('input[type="radio"][value="playwright"]').first();
+  await expect(playwrightRadio).toBeVisible({ timeout: 10000 });
+
+  const groupName = await playwrightRadio.getAttribute('name');
+  expect(groupName, 'framework radio group name').toBeTruthy();
+
+  const groupRadios = page.locator(`input[type="radio"][name="${groupName}"]`);
+  const checkedValues = await groupRadios.evaluateAll((els) =>
+    (els as HTMLInputElement[]).filter((e) => e.checked).map((e) => e.value)
+  );
+
+  expect(checkedValues).toHaveLength(1);
+  expect(checkedValues[0]).toBe('playwright');
+});

--- a/tests/e2e/pr-178/enum-framework-radio-group-rendered.spec.ts
+++ b/tests/e2e/pr-178/enum-framework-radio-group-rendered.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test('Test framework field renders Playwright/pytest/k6/Cypress radios', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  // Ensure things are expanded so radios are visible
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+
+  for (const label of ['Playwright', 'pytest', 'k6', 'Cypress']) {
+    const radio = page.locator(`label:has-text("${label}")`).locator('input[type="radio"]')
+      .or(page.locator(`input[type="radio"][value="${label.toLowerCase()}"]`));
+    await expect(radio.first()).toBeVisible({ timeout: 10000 });
+  }
+});

--- a/tests/e2e/pr-178/enum-selection-persists-after-save.spec.ts
+++ b/tests/e2e/pr-178/enum-selection-persists-after-save.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+
+test('Selecting "Offer as PR" persists across save and reload', async ({ page }) => {
+  // Navigate to workflows edit page
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+  const workflowsUrl = page.url();
+
+  // Make sure sections are expanded
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+
+  // Locate the suite lifecycle radio group via the "Offer as PR" option
+  const offerAsPrInput = page.locator('input[type="radio"][value="offer_as_pr"]')
+    .or(page.locator('label:has-text("Offer as PR")').locator('input[type="radio"]'))
+    .first();
+  await expect(offerAsPrInput).toBeVisible({ timeout: 10000 });
+
+  const groupName = await offerAsPrInput.getAttribute('name');
+  expect(groupName).toBeTruthy();
+
+  // Capture original checked value to restore later (idempotency)
+  const originalValue = await page.locator(`input[type="radio"][name="${groupName}"]`).evaluateAll(
+    (els) => (els as HTMLInputElement[]).find((e) => e.checked)?.value ?? null
+  );
+
+  // Try to enable E2E workflow checkbox if present and not yet enabled.
+  // Heuristic: find a checkbox in the same collapsible card as the radio group.
+  const e2eCheckbox = page.locator('input[type="checkbox"][name*="e2e" i], input[type="checkbox"][id*="e2e" i]').first();
+  const hadE2eCheckbox = await e2eCheckbox.count() > 0;
+  let e2eWasChecked = true;
+  if (hadE2eCheckbox) {
+    e2eWasChecked = await e2eCheckbox.isChecked().catch(() => true);
+    if (!e2eWasChecked) {
+      await e2eCheckbox.check().catch(() => {});
+    }
+  }
+
+  // Click "Offer as PR"
+  await offerAsPrInput.check({ force: true });
+  await expect(offerAsPrInput).toBeChecked();
+
+  // Submit the form
+  const submitBtn = page.locator('button[type="submit"], input[type="submit"]').first();
+  await submitBtn.waitFor({ state: 'visible', timeout: 10000 });
+  await Promise.all([
+    page.waitForLoadState('domcontentloaded'),
+    submitBtn.click(),
+  ]);
+  await page.waitForTimeout(500);
+
+  // Reload workflows edit page
+  await page.goto(workflowsUrl);
+  await page.waitForLoadState('domcontentloaded');
+
+  const expandBtn2 = page.locator('#expandAllWorkflows');
+  if (await expandBtn2.isVisible().catch(() => false)) {
+    await expandBtn2.click();
+    await page.waitForTimeout(800);
+  }
+
+  const offerAfter = page.locator(`input[type="radio"][name="${groupName}"][value="offer_as_pr"]`)
+    .or(page.locator('label:has-text("Offer as PR")').locator('input[type="radio"]'))
+    .first();
+  await expect(offerAfter).toBeChecked({ timeout: 10000 });
+
+  // --- Cleanup: restore original state for idempotency ---
+  if (originalValue && originalValue !== 'offer_as_pr') {
+    const original = page.locator(`input[type="radio"][name="${groupName}"][value="${originalValue}"]`).first();
+    if (await original.count() > 0) {
+      await original.check({ force: true }).catch(() => {});
+    }
+  }
+  if (hadE2eCheckbox && !e2eWasChecked) {
+    const cb = page.locator('input[type="checkbox"][name*="e2e" i], input[type="checkbox"][id*="e2e" i]').first();
+    if (await cb.isChecked().catch(() => false)) {
+      await cb.uncheck().catch(() => {});
+    }
+  }
+  const submitBtn2 = page.locator('button[type="submit"], input[type="submit"]').first();
+  if (await submitBtn2.isVisible().catch(() => false)) {
+    await submitBtn2.click().catch(() => {});
+    await page.waitForLoadState('domcontentloaded').catch(() => {});
+  }
+});

--- a/tests/e2e/pr-178/enum-suite-lifecycle-radio-group-rendered.spec.ts
+++ b/tests/e2e/pr-178/enum-suite-lifecycle-radio-group-rendered.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test('Suite lifecycle field renders the four expected radios', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const expandBtn = page.locator('#expandAllWorkflows');
+  if (await expandBtn.isVisible().catch(() => false)) {
+    await expandBtn.click();
+    await page.waitForTimeout(800);
+  }
+
+  for (const label of ['Ephemeral', 'Offer as PR', 'Promote on merge', 'Commit to PR']) {
+    const radioByLabel = page.locator(`label:has-text("${label}")`).first();
+    await expect(radioByLabel).toBeVisible({ timeout: 10000 });
+  }
+});

--- a/tests/e2e/pr-178/expand-all-shows-param-sections.spec.ts
+++ b/tests/e2e/pr-178/expand-all-shows-param-sections.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('Clicking Expand all adds show class to all wf-collapse-* elements', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  const collapseBtn = page.locator('#collapseAllWorkflows');
+  const expandBtn = page.locator('#expandAllWorkflows');
+  await collapseBtn.waitFor({ state: 'visible', timeout: 10000 });
+  await expandBtn.waitFor({ state: 'visible', timeout: 10000 });
+
+  const collapseTargets = page.locator("[id^='wf-collapse-']");
+  await expect.poll(async () => await collapseTargets.count(), { timeout: 10000 }).toBeGreaterThan(0);
+
+  // Known state: collapsed
+  await collapseBtn.click();
+  await page.waitForTimeout(800);
+
+  // Expand all
+  await expandBtn.click();
+  await page.waitForTimeout(800);
+
+  await expect.poll(async () => {
+    return await collapseTargets.evaluateAll((els) =>
+      els.every((el) => el.classList.contains('show'))
+    );
+  }, { timeout: 5000 }).toBe(true);
+});

--- a/tests/e2e/pr-178/expand-collapse-all-buttons-present.spec.ts
+++ b/tests/e2e/pr-178/expand-collapse-all-buttons-present.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Expand-all and Collapse-all buttons are visible on workflows edit page', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+  await page.waitForLoadState('domcontentloaded');
+
+  await expect(page.locator('#expandAllWorkflows')).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('#collapseAllWorkflows')).toBeVisible({ timeout: 10000 });
+});

--- a/tests/e2e/pr-178/system-settings-page-loads.spec.ts
+++ b/tests/e2e/pr-178/system-settings-page-loads.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+
+test('System settings page responds OK and renders without errors', async ({ page }) => {
+  // Navigate to root first
+  const rootResponse = await page.goto('/');
+  expect(rootResponse, 'root response defined').not.toBeNull();
+
+  // Open the /system-settings page
+  const response = await page.goto('/system-settings');
+  expect(response, 'response defined').not.toBeNull();
+  expect(response!.status(), 'HTTP status').toBeLessThan(400);
+
+  // Ensure page content has loaded
+  await page.waitForLoadState('domcontentloaded');
+
+  const bodyText = (await page.locator('body').innerText()).toLowerCase();
+  expect(bodyText).not.toContain('internal server error');
+  expect(bodyText).not.toContain('traceback');
+  expect(bodyText).not.toMatch(/\b500\b/);
+});

--- a/tests/e2e/pr-178/workflows-page-renders-heading.spec.ts
+++ b/tests/e2e/pr-178/workflows-page-renders-heading.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Workflows edit page shows "Workflows for" heading', async ({ page }) => {
+  await page.goto('/system-settings');
+  await page.waitForLoadState('domcontentloaded');
+
+  // Find a link leading to a workflows edit page
+  const workflowsLink = page.locator('a[href*="/workflows"]').first();
+  await workflowsLink.waitFor({ state: 'visible', timeout: 10000 });
+  await workflowsLink.click();
+
+  await page.waitForLoadState('domcontentloaded');
+  await expect(page.getByText(/Workflows for/i).first()).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
 **AI-Git-Bot** — automated test promotion (`offer-as-pr`).

Parent PR: **#178**. The bot generated the following end-to-end tests during the parent PR's E2E workflow and is offering them as a separate review.

**Files under `tests/e2e/pr-178/`:**

- `tests/e2e/pr-178/collapse-all-hides-param-sections.spec.ts`
- `tests/e2e/pr-178/collapse-state-persists-across-reload.spec.ts`
- `tests/e2e/pr-178/enum-default-selection.spec.ts`
- `tests/e2e/pr-178/enum-framework-radio-group-rendered.spec.ts`
- `tests/e2e/pr-178/enum-selection-persists-after-save.spec.ts`
- `tests/e2e/pr-178/enum-suite-lifecycle-radio-group-rendered.spec.ts`
- `tests/e2e/pr-178/expand-all-shows-param-sections.spec.ts`
- `tests/e2e/pr-178/expand-collapse-all-buttons-present.spec.ts`
- `tests/e2e/pr-178/system-settings-page-loads.spec.ts`
- `tests/e2e/pr-178/workflows-page-renders-heading.spec.ts`

---
> Tests are added as plain files — the standard CI is the source of truth. Please review for hidden assumptions, flaky selectors, and any secret/credential leakage before merging.
