### PR TITLE
feat: allow any user to interact with bot on PRs when no whitelist is…

### DIFF
--- a/src/main/java/org/remus/giteabot/admin/BotWebhookService.java
+++ b/src/main/java/org/remus/giteabot/admin/BotWebhookService.java
@@ -179,10 +179,13 @@ public class BotWebhookService {
     /**
      * Handles a comment on a PR discussion thread.
      * <p>
+     * Access control: if the bot has no {@code userWhitelist}, any user mentioning the bot
+     * may interact.  If a whitelist is configured, only the PR author <em>or</em> users listed
+     * in the whitelist may interact — all other commenters are ignored.
+     * <p>
      * Routes to the agent when an agent session exists for the PR (i.e. the PR was created by the
-     * agent and can be continued).  The agent-session path intentionally skips the PR-author check
-     * because the coding agent is the PR author; human follow-up comments must still reach the agent.
-     * For manually created PRs (no active session), only the PR author may issue commands.
+     * agent and can be continued).  For manually created PRs (no active session), the comment is
+     * routed to the code-review handler.
      */
     @Async
     public void handlePrComment(Bot bot, WebhookPayload payload) {
@@ -190,7 +193,7 @@ public class BotWebhookService {
             log.debug("[Bot '{}'] Writer bot ignores pull request comment", bot.getName());
             return;
         }
-        if (!isCallerAllowed(bot, payload)) {
+        if (!isPrCommenterAllowed(bot, payload)) {
             return;
         }
         String owner = payload.getRepository().getOwner().getLogin();
@@ -203,8 +206,6 @@ public class BotWebhookService {
                 || agentSessionService.getSessionByPr(owner, repo, prNumber).isPresent();
 
         if (hasAgentSession && bot.isAgentEnabled()) {
-            // Agent-session path: no author restriction – the coding agent created the PR,
-            // so any human commenter should be able to continue the implementation workflow.
             log.debug("[Bot '{}'] Agent session found for PR #{}, routing to agent", bot.getName(), prNumber);
             try {
                 createIssueImplementationService(bot).handleIssueComment(payload);
@@ -213,11 +214,6 @@ public class BotWebhookService {
                 botService.recordError(bot, e.getMessage());
             }
         } else {
-            // Code-review path: only the PR author may issue bot commands.
-            if (!isPullRequestAuthor(payload)) {
-                log.debug("[Bot '{}'] Ignoring pull request comment from non-author", bot.getName());
-                return;
-            }
             log.debug("[Bot '{}'] No agent session for PR #{}, routing to code-review handler",
                     bot.getName(), prNumber);
             try {
@@ -494,6 +490,40 @@ public class BotWebhookService {
             return payload.getIssue().getNumber();
         }
         return payload.getNumber();
+    }
+
+    /**
+     * Access-control check specific to {@link #handlePrComment(Bot, WebhookPayload)}.
+     *
+     * <p>Semantics:</p>
+     * <ul>
+     *   <li>If the bot has <strong>no</strong> {@code userWhitelist} → every commenter is allowed.</li>
+     *   <li>If a whitelist <strong>is</strong> configured → only the PR author <em>or</em> users
+     *       present in the whitelist may interact; everyone else is rejected.</li>
+     * </ul>
+     */
+    boolean isPrCommenterAllowed(Bot bot, WebhookPayload payload) {
+        if (bot == null) {
+            return true;
+        }
+        Set<String> allowed = botService.getAllowedUsernames(bot);
+        if (allowed.isEmpty()) {
+            // No whitelist → everyone may interact with the bot on PRs.
+            return true;
+        }
+        // Whitelist exists → allow PR author or whitelisted users.
+        if (isPullRequestAuthor(payload)) {
+            return true;
+        }
+        String caller = resolveCallerUsername(payload);
+        if (botService.isUsernameInSet(allowed, caller)) {
+            return true;
+        }
+        log.info("[Bot '{}'] Ignoring PR comment from '{}' — not PR author and not in whitelist ({} entries)",
+                bot.getName(),
+                caller == null ? "<unknown>" : caller,
+                allowed.size());
+        return false;
     }
 
     /**

--- a/src/test/java/org/remus/giteabot/admin/BotWebhookServiceTest.java
+++ b/src/test/java/org/remus/giteabot/admin/BotWebhookServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -803,8 +804,9 @@ class BotWebhookServiceTest {
         }
 
         @Test
-        void noAgentSession_nonAuthorComment_isIgnored() {
-            // No agent session and commenter is NOT the PR author → code-review path rejects it.
+        void noAgentSession_noWhitelist_nonAuthorComment_isAllowed() {
+            // No whitelist configured → any user mentioning the bot may interact,
+            // even if they are NOT the PR author.
             WebhookPayload nonAuthorPayload = buildPrCommentPayload(OWNER, REPO, PR_NUMBER, COMMENT_ID,
                     "@claude_bot please review");
             nonAuthorPayload.getComment().getUser().setLogin("other_user");
@@ -817,9 +819,79 @@ class BotWebhookServiceTest {
 
             botWebhookService.handlePrComment(createBot("bot", "claude_bot", true), nonAuthorPayload);
 
-            // Non-author on code-review path → no command handled
+            // Non-author but no whitelist → code-review path is entered
+            verify(sessionService).getOrCreateSession(OWNER, REPO, PR_NUMBER, "system-prompt:1");
+            verify(agentSessionService, never()).setStatus(any(), any());
+        }
+
+        @Test
+        void noAgentSession_whitelist_nonAuthorNotInWhitelist_isIgnored() {
+            // Whitelist configured and commenter is neither PR author nor in whitelist → rejected.
+            WebhookPayload nonAuthorPayload = buildPrCommentPayload(OWNER, REPO, PR_NUMBER, COMMENT_ID,
+                    "@claude_bot please review");
+            nonAuthorPayload.getComment().getUser().setLogin("stranger");
+            nonAuthorPayload.getSender().setLogin("stranger");
+
+            Bot bot = createBot("bot", "claude_bot", true);
+            bot.setUserWhitelist("alice, bob");
+            Set<String> allowedSet = Set.of("alice", "bob");
+            when(botService.getAllowedUsernames(bot)).thenReturn(allowedSet);
+            when(botService.isUsernameInSet(eq(allowedSet), eq("stranger"))).thenReturn(false);
+
+            botWebhookService.handlePrComment(bot, nonAuthorPayload);
+
             verify(sessionService, never()).getOrCreateSession(any(), any(), any(), any());
             verify(agentSessionService, never()).setStatus(any(), any());
+        }
+
+        @Test
+        void noAgentSession_whitelist_prAuthorNotInWhitelist_isAllowed() {
+            // Whitelist configured but commenter IS the PR author (not in whitelist) → allowed.
+            WebhookPayload authorPayload = buildPrCommentPayload(OWNER, REPO, PR_NUMBER, COMMENT_ID,
+                    "@claude_bot please review");
+            // PR author is "tom" (default), commenter is also "tom"
+            // Whitelist does NOT contain "tom"
+
+            when(agentSessionService.getSessionByIssue(OWNER, REPO, PR_NUMBER))
+                    .thenReturn(Optional.empty());
+            when(agentSessionService.getSessionByPr(OWNER, REPO, PR_NUMBER))
+                    .thenReturn(Optional.empty());
+
+            Bot bot = createBot("bot", "claude_bot", true);
+            bot.setUserWhitelist("alice, bob");
+            Set<String> allowedSet = Set.of("alice", "bob");
+            when(botService.getAllowedUsernames(bot)).thenReturn(allowedSet);
+
+            botWebhookService.handlePrComment(bot, authorPayload);
+
+            // PR author is allowed even though not in the whitelist
+            verify(sessionService).getOrCreateSession(OWNER, REPO, PR_NUMBER, "system-prompt:1");
+        }
+
+        @Test
+        void noAgentSession_whitelist_nonAuthorInWhitelist_isAllowed() {
+            // Whitelist configured and commenter is in whitelist (not PR author) → allowed.
+            WebhookPayload whitelistedPayload = buildPrCommentPayload(OWNER, REPO, PR_NUMBER, COMMENT_ID,
+                    "@claude_bot please review");
+            whitelistedPayload.getComment().getUser().setLogin("alice");
+            whitelistedPayload.getSender().setLogin("alice");
+            // PR author is "tom" (default), commenter "alice" is NOT the author but IS in whitelist
+
+            when(agentSessionService.getSessionByIssue(OWNER, REPO, PR_NUMBER))
+                    .thenReturn(Optional.empty());
+            when(agentSessionService.getSessionByPr(OWNER, REPO, PR_NUMBER))
+                    .thenReturn(Optional.empty());
+
+            Bot bot = createBot("bot", "claude_bot", true);
+            bot.setUserWhitelist("alice, bob");
+            Set<String> allowedSet = Set.of("alice", "bob");
+            when(botService.getAllowedUsernames(bot)).thenReturn(allowedSet);
+            when(botService.isUsernameInSet(eq(allowedSet), eq("alice"))).thenReturn(true);
+
+            botWebhookService.handlePrComment(bot, whitelistedPayload);
+
+            // Whitelisted user is allowed even though not the PR author
+            verify(sessionService).getOrCreateSession(OWNER, REPO, PR_NUMBER, "system-prompt:1");
         }
 
         @Test


### PR DESCRIPTION
… configured

    Previously, handlePrComment restricted interaction to the PR author only,
    regardless of whitelist settings. This change introduces dedicated
    access-control logic (isPrCommenterAllowed) for PR comments:

    - No whitelist configured: any user mentioning the bot may interact.
    - Whitelist configured: only the PR author OR users in the whitelist may interact; all others are ignored.

    The global isCallerAllowed method remains unchanged since it is shared
    by other webhook handlers with different access requirements.

    Tests added:
    - noAgentSession_noWhitelist_nonAuthorComment_isAllowed
    - noAgentSession_whitelist_nonAuthorNotInWhitelist_isIgnored
    - noAgentSession_whitelist_prAuthorNotInWhitelist_isAllowed
    - noAgentSession_whitelist_nonAuthorInWhitelist_isAllowed