### PR TITLE
fix: avoid cascade-delete on workflow configuration update

### DIFF
--- a/src/main/java/org/remus/giteabot/prworkflow/config/WorkflowConfigurationService.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/config/WorkflowConfigurationService.java
@@ -52,28 +52,32 @@ public class WorkflowConfigurationService {
         if (configuration.getName() == null || configuration.getName().isBlank()) {
             throw new IllegalArgumentException("Name is required");
         }
-        configuration.setName(configuration.getName().trim());
+        String trimmedName = configuration.getName().trim();
 
         if (configuration.getId() != null) {
+            // Existing: update only name on the managed entity. The detached
+            // entity from form binding has an empty selectedWorkflows list —
+            // saving it directly would cascade-delete all persisted selections.
             WorkflowConfiguration existing = configurationRepository.findById(configuration.getId())
                     .orElseThrow(() -> new IllegalArgumentException("Workflow configuration not found"));
             if (existing.isDefaultEntry()) {
-                if (!existing.getName().equals(configuration.getName())) {
+                if (!existing.getName().equals(trimmedName)) {
                     throw new IllegalArgumentException("The default workflow configuration cannot be renamed");
                 }
-                configuration.setDefaultEntry(true);
             }
-        } else {
-            // New configurations are never default; the default is bootstrapped once.
-            configuration.setDefaultEntry(false);
+            if (configurationRepository.existsByNameAndIdNot(trimmedName, configuration.getId())) {
+                throw new IllegalArgumentException("A workflow configuration with this name already exists");
+            }
+            existing.setName(trimmedName);
+            return existing;
         }
 
-        boolean duplicateName = configuration.getId() == null
-                ? configurationRepository.existsByName(configuration.getName())
-                : configurationRepository.existsByNameAndIdNot(configuration.getName(), configuration.getId());
-        if (duplicateName) {
+        // New configurations are never default; the default is bootstrapped once.
+        if (configurationRepository.existsByName(trimmedName)) {
             throw new IllegalArgumentException("A workflow configuration with this name already exists");
         }
+        configuration.setName(trimmedName);
+        configuration.setDefaultEntry(false);
         return configurationRepository.save(configuration);
     }
 

--- a/src/test/java/org/remus/giteabot/prworkflow/config/WorkflowConfigurationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/config/WorkflowConfigurationServiceTest.java
@@ -94,8 +94,6 @@ class WorkflowConfigurationServiceTest {
         update.setDefaultEntry(false);
         when(configurationRepository.findById(1L)).thenReturn(Optional.of(persisted));
         when(configurationRepository.existsByNameAndIdNot("Default", 1L)).thenReturn(false);
-        when(configurationRepository.save(any(WorkflowConfiguration.class)))
-                .thenAnswer(inv -> inv.getArgument(0));
 
         WorkflowConfiguration saved = service.save(update);
         assertTrue(saved.isDefaultEntry());


### PR DESCRIPTION
Saving the detached entity from form binding directly in the update
path would cascade-delete all persisted selectedWorkflows, because the
detached entity's list is empty. The fix now fetches the managed
entity via findById, updates its name, and returns the managed
entity instead — preserving the workflow associations.