### PR TITLE
fix(gitea): route PR conversation comments to handlePrComment

### DIFF
--- a/src/main/java/org/remus/giteabot/gitea/GiteaWebhookHandler.java
+++ b/src/main/java/org/remus/giteabot/gitea/GiteaWebhookHandler.java
@@ -65,6 +65,28 @@ public class GiteaWebhookHandler {
         return payload;
     }
 
+    /**
+     * Promotes a nested {@code issue.pull_request} marker to a minimal top-level
+     * {@link WebhookPayload.PullRequest} so PR-comment handling (which reads
+     * {@code payload.getPullRequest()}) works on Gitea's {@code issue_comment}
+     * payloads, where a PR is only signalled inside the issue. No-op when a
+     * top-level PR is already present or there is no issue. For PRs in Gitea the
+     * issue number equals the PR number and the issue title/body/author mirror
+     * the PR's.
+     */
+    private void promoteIssueToPullRequest(WebhookPayload payload) {
+        if (payload.getPullRequest() != null || payload.getIssue() == null) {
+            return;
+        }
+        WebhookPayload.Issue issue = payload.getIssue();
+        WebhookPayload.PullRequest pr = new WebhookPayload.PullRequest();
+        pr.setNumber(issue.getNumber());
+        pr.setTitle(issue.getTitle());
+        pr.setBody(issue.getBody());
+        pr.setUser(issue.getUser());
+        payload.setPullRequest(pr);
+    }
+
     // ---- Extraction helpers ----
 
     private WebhookPayload.Owner extractOwner(Map<String, Object> owner) {
@@ -222,7 +244,16 @@ public class GiteaWebhookHandler {
                         payload.getComment().getId(), botAlias);
                 return ResponseEntity.ok("ignored");
             }
-            if (payload.getPullRequest() != null) {
+            // A PR conversation comment arrives as an issue_comment event: Gitea marks it via
+            // issue.pull_request (nested), not a top-level pull_request. Treat either signal as
+            // "this comment is on a PR" so mentions reach handlePrComment (review / slash
+            // commands) instead of the agent-gated handleIssueComment.
+            boolean isPrComment = payload.getPullRequest() != null
+                    || (payload.getIssue() != null && payload.getIssue().getPullRequest() != null);
+            if (isPrComment) {
+                // handlePrComment dereferences payload.getPullRequest().getNumber(); when only the
+                // nested issue.pull_request was present, promote a minimal top-level PR first.
+                promoteIssueToPullRequest(payload);
                 // Comment on a PR discussion thread — let BotWebhookService decide whether to
                 // route to the agent (session exists) or the code-review handler (no session).
                 botWebhookService.handlePrComment(bot, payload);

--- a/src/test/java/org/remus/giteabot/gitea/GiteaWebhookHandlerTest.java
+++ b/src/test/java/org/remus/giteabot/gitea/GiteaWebhookHandlerTest.java
@@ -3,6 +3,7 @@ package org.remus.giteabot.gitea;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.remus.giteabot.admin.Bot;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.*;
 
 /**
@@ -103,6 +105,33 @@ class GiteaWebhookHandlerTest {
 
         assertEquals("ignored", response.getBody());
         verify(botWebhookService, never()).handleIssueComment(any(), any());
+    }
+
+    @Test
+    void prConversationComment_withoutTopLevelPullRequest_routesToHandlePrComment() {
+        // Real Gitea delivers a PR-conversation comment as an issue_comment event with
+        // issue.pull_request set but NO top-level pull_request. It must route to
+        // handlePrComment (review/slash commands), not the agent-gated handleIssueComment.
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("action", "created");
+        payload.put("sender", ownerMap("tom"));
+        payload.put("repository", repositoryMap());
+        payload.put("issue", issueMap(140L, true));   // issue WITH pull_request link
+        // deliberately no top-level "pull_request" key
+        payload.put("comment", commentMap(1055L, BOT_ALIAS + " please re-review", null));
+
+        ResponseEntity<String> response = handler.handleWebhook(bot, payload);
+
+        assertEquals("pr comment received", response.getBody());
+        ArgumentCaptor<WebhookPayload> captor = ArgumentCaptor.forClass(WebhookPayload.class);
+        verify(botWebhookService).handlePrComment(eq(bot), captor.capture());
+        verify(botWebhookService, never()).handleIssueComment(any(), any());
+        // Downstream handlePrComment dereferences payload.getPullRequest().getNumber();
+        // the handler must promote a top-level PR so it does not NPE.
+        WebhookPayload routed = captor.getValue();
+        assertNotNull(routed.getPullRequest(),
+                "PR conversation comment must carry a promoted top-level pull_request");
+        assertEquals(140L, routed.getPullRequest().getNumber());
     }
 
     // ---- Bot's own events are ignored ----


### PR DESCRIPTION
## What

Route Gitea PR-conversation comments to `handlePrComment` even when the webhook payload carries the PR marker only in the nested `issue.pull_request` field.

Fixes #250.

## Why

Gitea delivers a comment posted in a pull request's conversation as an `issue_comment` webhook whose PR-ness is signalled by `issue.pull_request`, not a top-level `pull_request`. `GiteaWebhookHandler` routed on the top-level field alone, so `@`-mentions on a PR fell through to `handleIssueComment` — which is gated behind the bot's agent feature — and were dropped with "Agent feature disabled, ignoring issue comment" when the agent was off.

## How

- Treat either signal (top-level `pull_request` **or** nested `issue.pull_request`) as a PR comment.
- Promote the nested marker to a minimal top-level `PullRequest` (number/title/body/author copied from the issue — for PRs in Gitea these mirror the PR) before delegating, because `handlePrComment` dereferences `payload.getPullRequest().getNumber()`.

## Tests

- Added `GiteaWebhookHandlerTest#prConversationComment_withoutTopLevelPullRequest_routesToHandlePrComment`: an `issue_comment` payload with `issue.pull_request` set and no top-level `pull_request` now routes to `handlePrComment` and carries a promoted top-level PR (asserts number == issue number). Written test-first (red → green).
- `mvn -Dtest=GiteaWebhookHandlerTest test` → green (20 tests, 0 failures).

Targets `develop` per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
