### PR TITLE
fix(review): include current diff in bot follow-ups

### DIFF
--- a/src/main/java/org/remus/giteabot/review/CodeReviewService.java
+++ b/src/main/java/org/remus/giteabot/review/CodeReviewService.java
@@ -174,10 +174,15 @@ public class CodeReviewService {
 
             // Get or create session
             ReviewSession session = sessionService.getOrCreateSession(owner, repo, prNumber, sessionPromptKey);
+            boolean newSession = session.getMessages().isEmpty();
+            String diff = fetchFilteredDiff(owner, repo, prNumber);
+            if (diff == null) {
+                log.warn("Failed to fetch diff for PR #{} in {}/{}", prNumber, owner, repo);
+                return;
+            }
 
             // If session is empty, add context from the PR
-            if (session.getMessages().isEmpty()) {
-                String diff = fetchFilteredDiff(owner, repo, prNumber);
+            if (newSession) {
                 var prContext = buildPrContextString(payload, diff, owner, repo, prNumber);
                 sessionService.addMessage(session, "user", prContext);
                 sessionService.addMessage(session, "assistant",
@@ -186,12 +191,15 @@ public class CodeReviewService {
 
             // Send the comment as a new message in the conversation
             List<AiMessage> history = sessionService.toAiMessages(session);
+            String messageForAi = newSession
+                    ? commentBody
+                    : buildBotCommandFollowUpMessage(commentBody, diff);
             log.debug("LLM request [chat/botCommand] for PR #{}: history size={}, commentBody length={}, systemPrompt length={}",
                     prNumber, history.size(), commentBody.length(),
                     systemPrompt != null ? systemPrompt.length() : 0);
             log.debug("LLM request [chat/botCommand] user message: '{}'",
                     commentBody.substring(0, Math.min(commentBody.length(), 500)));
-            String response = aiClient.chat(history, commentBody, systemPrompt, null);
+            String response = aiClient.chat(history, messageForAi, systemPrompt, null);
             log.debug("LLM response [chat/botCommand] for PR #{}: length={}, preview='{}'",
                     prNumber, response != null ? response.length() : 0,
                     response != null ? response.substring(0, Math.min(response.length(), 500)) : "null");
@@ -239,6 +247,17 @@ public class CodeReviewService {
         }
 
         return prContext;
+    }
+
+    private String buildBotCommandFollowUpMessage(String commentBody, String diff) {
+        if (diff == null || diff.isBlank()) {
+            return commentBody;
+        }
+        String truncatedDiff = diff.length() > MAX_DIFF_CHARS_FOR_CONTEXT
+                ? diff.substring(0, MAX_DIFF_CHARS_FOR_CONTEXT) + "\n...(truncated)"
+                : diff;
+        return commentBody + "\n\nCurrent pull request diff:\n```diff\n"
+                + truncatedDiff + "\n```";
     }
 
     public void handleInlineComment(WebhookPayload payload, String promptName) {

--- a/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
+++ b/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -29,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -211,6 +213,34 @@ class CodeReviewServiceTest {
     }
 
     @Test
+    void handleBotCommand_commentWriteFailurePropagates() {
+        WebhookPayload payload = createCommentPayload("@ai_bot explain this");
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+        session.addMessage("assistant", "Initial review");
+        IllegalStateException writeFailure = new IllegalStateException("comment write failed");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(sessionService.addMessage(any(), anyString(), anyString())).thenReturn(session);
+        when(sessionService.toAiMessages(session)).thenReturn(List.of(
+                AiMessage.builder().role("user").content("Initial context").build(),
+                AiMessage.builder().role("assistant").content("Initial review").build()
+        ));
+        when(repositoryClient.getPullRequestDiff(any(), any(), anyLong())).thenReturn("Some random diff");
+        when(aiClient.chat(anyList(), anyString(), eq(TEST_PROMPT), isNull()))
+                .thenReturn("Generated response");
+        doThrow(writeFailure).when(repositoryClient)
+                .postPullRequestComment(eq("testowner"), eq("testrepo"), eq(1L), anyString());
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> codeReviewService.handleBotCommand(payload, null));
+
+        assertEquals(writeFailure, thrown);
+        verify(sessionService, never()).compactContextWindow(session);
+    }
+
+    @Test
     void handleBotCommand_existingSessionIncludesLatestDiffButStoresOriginalComment() {
         String comment = "@ai_bot explain the updated implementation";
         String latestDiff = "diff --git a/Foo.java b/Foo.java\n+int current = 2;";
@@ -303,7 +333,8 @@ class CodeReviewServiceTest {
         when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
                 .thenThrow(new IllegalStateException("diff fetch failed"));
 
-        codeReviewService.handleBotCommand(payload, null);
+
+        assertThrows(IllegalStateException.class, () ->codeReviewService.handleBotCommand(payload, null));
 
         verify(aiClient, never()).chat(anyList(), anyString(), anyString(), isNull());
         verify(repositoryClient, never()).postPullRequestComment(

--- a/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
+++ b/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
@@ -199,6 +199,8 @@ class CodeReviewServiceTest {
                 AiMessage.builder().role("user").content("Initial context").build(),
                 AiMessage.builder().role("assistant").content("Initial review").build()
         ));
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn("");
         when(aiClient.chat(anyList(), eq("@ai_bot explain this"), eq(TEST_PROMPT), isNull()))
                 .thenReturn("Here's my explanation");
 
@@ -206,6 +208,124 @@ class CodeReviewServiceTest {
 
         verify(repositoryClient).addReaction("testowner", "testrepo", 42L, "eyes");
         verify(repositoryClient).postPullRequestComment(eq("testowner"), eq("testrepo"), eq(1L), contains("Here's my explanation"));
+    }
+
+    @Test
+    void handleBotCommand_existingSessionIncludesLatestDiffButStoresOriginalComment() {
+        String comment = "@ai_bot explain the updated implementation";
+        String latestDiff = "diff --git a/Foo.java b/Foo.java\n+int current = 2;";
+        WebhookPayload payload = createCommentPayload(comment);
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+        session.addMessage("assistant", "Initial review");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(sessionService.addMessage(any(), anyString(), anyString())).thenReturn(session);
+        when(sessionService.toAiMessages(session)).thenReturn(List.of(
+                AiMessage.builder().role("user").content("Initial context").build(),
+                AiMessage.builder().role("assistant").content("Initial review").build()
+        ));
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn(latestDiff);
+        when(aiClient.chat(anyList(), anyString(), eq(TEST_PROMPT), isNull()))
+                .thenReturn("Updated explanation");
+
+        codeReviewService.handleBotCommand(payload, null);
+
+        ArgumentCaptor<String> modelInput = ArgumentCaptor.forClass(String.class);
+        verify(aiClient).chat(anyList(), modelInput.capture(), eq(TEST_PROMPT), isNull());
+        assertTrue(modelInput.getValue().contains(comment));
+        assertTrue(modelInput.getValue().contains("Current pull request diff:"));
+        assertTrue(modelInput.getValue().contains(latestDiff));
+        verify(sessionService).addMessage(session, "user", comment);
+        verify(sessionService).addMessage(session, "assistant", "Updated explanation");
+    }
+
+    @Test
+    void handleBotCommand_newSessionKeepsDiffInInitialContextOnly() {
+        String comment = "@ai_bot explain this";
+        String latestDiff = "diff --git a/Foo.java b/Foo.java\n+int current = 2;";
+        WebhookPayload payload = createCommentPayload(comment);
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(sessionService.addMessage(any(), anyString(), anyString())).thenReturn(session);
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn(latestDiff);
+        when(aiClient.chat(anyList(), eq(comment), eq(TEST_PROMPT), isNull()))
+                .thenReturn("Explanation");
+
+        codeReviewService.handleBotCommand(payload, null);
+
+        verify(sessionService).addMessage(eq(session), eq("user"), contains(latestDiff));
+        verify(aiClient).chat(anyList(), eq(comment), eq(TEST_PROMPT), isNull());
+        verify(sessionService).addMessage(session, "user", comment);
+    }
+
+    @Test
+    void handleBotCommand_existingSessionTruncatesLatestDiff() {
+        String comment = "@ai_bot inspect the latest change";
+        String omittedTail = "OMITTED_TAIL";
+        String oversizedDiff = "x".repeat(CodeReviewService.MAX_DIFF_CHARS_FOR_CONTEXT) + omittedTail;
+        WebhookPayload payload = createCommentPayload(comment);
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(sessionService.addMessage(any(), anyString(), anyString())).thenReturn(session);
+        when(sessionService.toAiMessages(session)).thenReturn(List.of(
+                AiMessage.builder().role("user").content("Initial context").build()
+        ));
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn(oversizedDiff);
+        when(aiClient.chat(anyList(), anyString(), eq(TEST_PROMPT), isNull()))
+                .thenReturn("Result");
+
+        codeReviewService.handleBotCommand(payload, null);
+
+        ArgumentCaptor<String> modelInput = ArgumentCaptor.forClass(String.class);
+        verify(aiClient).chat(anyList(), modelInput.capture(), eq(TEST_PROMPT), isNull());
+        assertTrue(modelInput.getValue().contains("...(truncated)"));
+        assertFalse(modelInput.getValue().contains(omittedTail));
+    }
+
+    @Test
+    void handleBotCommand_existingSessionStopsWhenLatestDiffFetchFails() {
+        WebhookPayload payload = createCommentPayload("@ai_bot inspect the latest change");
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenThrow(new IllegalStateException("diff fetch failed"));
+
+        codeReviewService.handleBotCommand(payload, null);
+
+        verify(aiClient, never()).chat(anyList(), anyString(), anyString(), isNull());
+        verify(repositoryClient, never()).postPullRequestComment(
+                anyString(), anyString(), anyLong(), anyString());
+    }
+
+    @Test
+    void handleBotCommand_existingSessionStopsWhenLatestDiffIsNull() {
+        WebhookPayload payload = createCommentPayload("@ai_bot inspect the latest change");
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn(null);
+
+        codeReviewService.handleBotCommand(payload, null);
+
+        verify(aiClient, never()).chat(anyList(), anyString(), anyString(), isNull());
+        verify(repositoryClient, never()).postPullRequestComment(
+                anyString(), anyString(), anyLong(), anyString());
     }
 
     @Test
@@ -570,6 +690,8 @@ class CodeReviewServiceTest {
                 AiMessage.builder().role("user").content("Initial context").build(),
                 AiMessage.builder().role("assistant").content("Initial review").build()
         ));
+        when(repositoryClient.getPullRequestDiff("testowner", "testrepo", 1L))
+                .thenReturn("");
         when(aiClient.chat(anyList(), eq("@ai_bot explain this"), eq(TEST_PROMPT), isNull()))
                 .thenReturn("");
 


### PR DESCRIPTION
## What

Refresh the filtered pull-request diff for existing `@bot` review conversations and include it only in the current model input.

## Why

After new commits, an existing session otherwise answers from stale review context or has no current diff.

## How

- Fetch the latest diff through the shared `RepositoryApiClient`.
- Apply the existing 60,000-character context cap and truncation marker.
- Keep the persisted user comment unchanged; the diff is transient model input only.

## Provider scope

This change is provider-neutral and applies to all supported providers. It does not change provider adapters or webhook routing.

## Tests

- Existing sessions receive the latest filtered diff.
- Diff-fetch failures stop before the AI call and response comment.
- Session history persists the original user comment.
- New-session behavior remains unchanged.
- Oversized diffs are truncated with the existing marker.
- Full `mvn --batch-mode clean verify` passes.

Fixes #273

## AI involvement

AI assistance was used to:

- inspect the relevant repository and cross-provider code paths;
- compare webhook behavior across the supported Git providers;
- draft the tests and implementation;
- identify edge cases and prepare the pull request description.

The contributor:

- provided the original failure context and expected behavior;
- selected and approved the final scope and design;
- retained responsibility for the submitted changes.

The changes were validated with focused tests and the full test suite before submission.
