### PR TITLE
fix(review): propagate bot response write failures

### DIFF
--- a/src/main/java/org/remus/giteabot/review/CodeReviewService.java
+++ b/src/main/java/org/remus/giteabot/review/CodeReviewService.java
@@ -215,6 +215,13 @@ public class CodeReviewService {
         } catch (Exception e) {
             log.error("Failed to handle bot command for comment #{} on PR #{} in {}/{}: {}",
                     commentId, prNumber, owner, repo, e.getMessage(), e);
+            if (e instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw new IllegalStateException(
+                    "Failed to handle bot command for comment #" + commentId
+                            + " on PR #" + prNumber,
+                    e);
         }
     }
 

--- a/src/test/java/org/remus/giteabot/prworkflow/review/ReviewWorkflowTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/review/ReviewWorkflowTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -93,6 +94,26 @@ class ReviewWorkflowTest {
 
         assertEquals(WorkflowResultStatus.SKIPPED, result.status());
         verify(repoClient, never()).postReviewAction(any(), any(), anyLong(), any());
+    }
+
+    @Test
+    void botCommandFailureIsExposedInsteadOfReturningSuccess() {
+        Bot bot = botWith(PostReviewAction.NONE);
+        WebhookPayload payload = payloadFor("acme", "web", 10L);
+        IllegalStateException writeFailure = new IllegalStateException("comment write failed");
+        doThrow(writeFailure).when(codeReviewService).handleBotCommand(payload, null);
+        PrWorkflowContext context = new PrWorkflowContext(
+                bot,
+                payload,
+                1L,
+                (name, log) -> { },
+                () -> false,
+                Map.of(ReviewWorkflow.HINT_REVIEW_ACTION, ReviewWorkflow.ACTION_BOT_COMMAND));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> workflow.run(context));
+
+        assertEquals(writeFailure, thrown);
     }
 
     private static PrWorkflowContext ctx(Bot bot, WebhookPayload payload) {

--- a/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
+++ b/src/test/java/org/remus/giteabot/review/CodeReviewServiceTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -29,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -206,6 +208,33 @@ class CodeReviewServiceTest {
 
         verify(repositoryClient).addReaction("testowner", "testrepo", 42L, "eyes");
         verify(repositoryClient).postPullRequestComment(eq("testowner"), eq("testrepo"), eq(1L), contains("Here's my explanation"));
+    }
+
+    @Test
+    void handleBotCommand_commentWriteFailurePropagates() {
+        WebhookPayload payload = createCommentPayload("@ai_bot explain this");
+        ReviewSession session = new ReviewSession("testowner", "testrepo", 1L, null);
+        session.addMessage("user", "Initial context");
+        session.addMessage("assistant", "Initial review");
+        IllegalStateException writeFailure = new IllegalStateException("comment write failed");
+
+        when(sessionService.getOrCreateSession("testowner", "testrepo", 1L, SESSION_PROMPT_KEY))
+                .thenReturn(session);
+        when(sessionService.addMessage(any(), anyString(), anyString())).thenReturn(session);
+        when(sessionService.toAiMessages(session)).thenReturn(List.of(
+                AiMessage.builder().role("user").content("Initial context").build(),
+                AiMessage.builder().role("assistant").content("Initial review").build()
+        ));
+        when(aiClient.chat(anyList(), eq("@ai_bot explain this"), eq(TEST_PROMPT), isNull()))
+                .thenReturn("Generated response");
+        doThrow(writeFailure).when(repositoryClient)
+                .postPullRequestComment(eq("testowner"), eq("testrepo"), eq(1L), anyString());
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> codeReviewService.handleBotCommand(payload, null));
+
+        assertEquals(writeFailure, thrown);
+        verify(sessionService, never()).compactContextWindow(session);
     }
 
     @Test


### PR DESCRIPTION
## What

Propagate failures from conversational PR-response handling so a failed comment write cannot be reported as a successful review workflow.

## Why

`CodeReviewService#handleBotCommand` currently logs and swallows every exception. When the provider rejects `postPullRequestComment`, the workflow can still finish successfully even though the user received no response.

## How

- keep the existing detailed error log;
- rethrow runtime failures and wrap an unexpected checked failure;
- rely on the existing workflow orchestrator to persist `FAILED` and on existing bot-level handling to record the error;
- add no automatic POST retry.

## Provider scope

The change is provider-neutral and applies to every supported provider through `RepositoryApiClient`. No provider client or webhook route changes.

## Tests

- comment-write exception propagates from `handleBotCommand`;
- `ReviewWorkflow` exposes the failure instead of returning success;
- the orchestrator exception-to-`FAILED` regression remains green;
- `mvn --batch-mode clean verify`.

Fixes #274

## AI involvement

AI assistance was used to:
- inspect the relevant repository and cross-provider code paths;
- compare webhook behavior across the supported Git providers;
- draft the tests and implementation;
- identify edge cases and prepare the pull request description.

The contributor:
- provided the original failure context and expected behavior;
- selected and approved the final scope and design;
- retained responsibility for the submitted changes.

The changes were validated with focused tests and the full test suite before
submission.
