### PR TITLE
verify inbound webhook signatures

### DIFF
--- a/doc/GITEA_SETUP.md
+++ b/doc/GITEA_SETUP.md
@@ -76,7 +76,7 @@ Code reviews are explicit-request only: pushes to an existing pull request do no
    - **Target URL:** Paste the bot's webhook URL
    - **HTTP Method:** POST
    - **Content Type:** application/json
-   - **Secret:** (leave empty — authentication is via the URL path)
+   - **Secret:** Set a strong random secret here and enter the same value as **Webhook signing secret** on the bot. AI-Git-Bot then verifies the `X-Gitea-Signature` HMAC of every delivery and rejects forged events. (Leave empty only on fully trusted networks — authentication then relies solely on the URL path secret.)
 3. Under **Trigger On**, select **Custom Events**, then enable:
    - ✅ **Pull Request** — handles PR open/close events and reviewer requests/re-requests
    - ✅ **Pull Request Comment** — allows the bot to respond to inline code review comments

--- a/doc/GITHUB_SETUP.md
+++ b/doc/GITHUB_SETUP.md
@@ -99,7 +99,7 @@ Code reviews are explicit-request only: pushes to an existing pull request do no
 2. Configure:
    - **Payload URL:** Paste the bot's webhook URL
    - **Content type:** `application/json`
-   - **Secret:** (leave empty — authentication is via the URL path)
+   - **Secret:** Set a strong random secret here and enter the same value as **Webhook signing secret** on the bot. AI-Git-Bot then verifies the `X-Hub-Signature-256` HMAC of every delivery and rejects forged events. (Leave empty only on fully trusted networks — authentication then relies solely on the URL path secret.)
 3. Under **Which events would you like to trigger this webhook?**, select **Let me select individual events**, then enable:
    - ✅ **Pull requests** (PR opened, reviewer added, reviewer re-requested)
    - ✅ **Pull request reviews**

--- a/doc/GITLAB_SETUP.md
+++ b/doc/GITLAB_SETUP.md
@@ -99,7 +99,7 @@ Code reviews are explicit-request only: pushes to an existing merge request do n
 2. Click **Add new webhook**
 3. Configure:
    - **URL:** Paste the bot's webhook URL
-   - **Secret token:** (leave empty — authentication is via the URL path)
+   - **Secret token:** Set a strong random secret here and enter the same value as **Webhook signing secret** on the bot. AI-Git-Bot then compares the `X-Gitlab-Token` header of every delivery and rejects forged events. (Leave empty only on fully trusted networks — authentication then relies solely on the URL path secret.)
 4. Under **Trigger**, enable:
    - ✅ **Merge request events** (MR opened, reviewer added/re-requested, MR closed/merged)
    - ✅ **Comments** (for bot commands in MR comments and review-request fallback comments)

--- a/src/main/java/org/remus/giteabot/admin/Bot.java
+++ b/src/main/java/org/remus/giteabot/admin/Bot.java
@@ -70,6 +70,14 @@ public class Bot {
 
     private String webhookSecret;
 
+    /**
+     * Optional shared secret used to verify the provider's webhook signature
+     * (HMAC or token header) in addition to the URL path secret. Stored
+     * encrypted via {@link EncryptionService} (see {@link BotService#save}).
+     */
+    @Column(name = "webhook_signing_secret", length = 1000)
+    private String webhookSigningSecret;
+
     @Column(name = "user_whitelist", columnDefinition = "TEXT")
     private String userWhitelist;
 

--- a/src/main/java/org/remus/giteabot/admin/BotController.java
+++ b/src/main/java/org/remus/giteabot/admin/BotController.java
@@ -94,6 +94,7 @@ public class BotController {
                         @RequestParam(required = false) Long workflowConfigurationId,
                         @RequestParam(required = false) Long issueWorkflowConfigurationId,
                         @RequestParam(required = false) Long deploymentTargetId,
+                        @RequestParam(defaultValue = "false") boolean clearWebhookSigningSecret,
                         Model model,
                         RedirectAttributes redirectAttributes) {
         try {
@@ -139,7 +140,7 @@ public class BotController {
                         .orElseThrow(() -> new IllegalArgumentException("Deployment target not found"));
             }
             bot.setDeploymentTarget(deploymentTarget);
-            botService.save(bot);
+            botService.save(bot, clearWebhookSigningSecret);
             redirectAttributes.addFlashAttribute("success", "Bot saved successfully");
         } catch (Exception e) {
             log.error("Failed to save Bot", e);

--- a/src/main/java/org/remus/giteabot/admin/BotService.java
+++ b/src/main/java/org/remus/giteabot/admin/BotService.java
@@ -23,6 +23,7 @@ public class BotService {
 
     private final BotRepository botRepository;
     private final BotToolConfigurationRepository botToolConfigurationRepository;
+    private final EncryptionService encryptionService;
 
     @Transactional(readOnly = true)
     public List<Bot> findAll() {
@@ -43,6 +44,18 @@ public class BotService {
         if (bot.getWebhookSecret() == null) {
             bot.setWebhookSecret(UUID.randomUUID().toString());
         }
+        // Encrypt a newly provided webhook signing secret; keep the stored one
+        // when the form field is left blank on update (same pattern as the
+        // git integration token).
+        String signingSecret = bot.getWebhookSigningSecret();
+        if (signingSecret != null && !signingSecret.isBlank()) {
+            bot.setWebhookSigningSecret(encryptionService.encrypt(signingSecret));
+        } else if (bot.getId() != null) {
+            botRepository.findById(bot.getId())
+                    .ifPresent(existing -> bot.setWebhookSigningSecret(existing.getWebhookSigningSecret()));
+        } else {
+            bot.setWebhookSigningSecret(null);
+        }
         if (bot.getToolConfiguration() == null) {
             // Defensive fallback for callers that bypass the BotController
             // (integration tests, scripts): assign the Default tool
@@ -62,6 +75,19 @@ public class BotService {
                             + "explicitly before saving the bot.");
         }
         return botRepository.save(bot);
+    }
+
+    /**
+     * Returns the bot's decrypted webhook signing secret, or {@code null} when
+     * none is configured (signature verification then stays disabled).
+     */
+    @Transactional(readOnly = true)
+    public String getDecryptedWebhookSigningSecret(Bot bot) {
+        String secret = bot.getWebhookSigningSecret();
+        if (secret == null || secret.isBlank()) {
+            return null;
+        }
+        return encryptionService.decrypt(secret);
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/org/remus/giteabot/admin/BotService.java
+++ b/src/main/java/org/remus/giteabot/admin/BotService.java
@@ -41,15 +41,29 @@ public class BotService {
     }
 
     public Bot save(Bot bot) {
+        return save(bot, false);
+    }
+
+    /**
+     * Saves a bot, resolving the webhook signing secret from the form input.
+     *
+     * <p>The secret field is a one-way write: the stored value is never echoed
+     * back into the form. A blank field therefore means "keep the stored
+     * value", while {@code clearSigningSecret} requests explicit removal (the
+     * Clear button in the UI).</p>
+     */
+    public Bot save(Bot bot, boolean clearSigningSecret) {
         if (bot.getWebhookSecret() == null) {
             bot.setWebhookSecret(UUID.randomUUID().toString());
         }
         // Encrypt a newly provided webhook signing secret; keep the stored one
         // when the form field is left blank on update (same pattern as the
-        // git integration token).
+        // git integration token). The explicit Clear button overrides keeping.
         String signingSecret = bot.getWebhookSigningSecret();
         if (signingSecret != null && !signingSecret.isBlank()) {
             bot.setWebhookSigningSecret(encryptionService.encrypt(signingSecret));
+        } else if (clearSigningSecret) {
+            bot.setWebhookSigningSecret(null);
         } else if (bot.getId() != null) {
             botRepository.findById(bot.getId())
                     .ifPresent(existing -> bot.setWebhookSigningSecret(existing.getWebhookSigningSecret()));

--- a/src/main/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilter.java
+++ b/src/main/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilter.java
@@ -34,6 +34,9 @@ public class ApiPayloadSizeLimitFilter extends OncePerRequestFilter {
 
     private final long maxBodyBytes;
 
+    /**
+     * @param maxBodyBytes maximum accepted request body size for {@code /api/**}
+     */
     public ApiPayloadSizeLimitFilter(
             @Value("${giteabot.api.max-body-bytes:2097152}") long maxBodyBytes) {
         this.maxBodyBytes = maxBodyBytes;
@@ -41,7 +44,9 @@ public class ApiPayloadSizeLimitFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return !request.getRequestURI().startsWith("/api/");
+        String pathWithinApplication = request.getRequestURI()
+                .substring(request.getContextPath().length());
+        return !pathWithinApplication.startsWith("/api/");
     }
 
     @Override

--- a/src/main/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilter.java
+++ b/src/main/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilter.java
@@ -1,0 +1,135 @@
+package org.remus.giteabot.webhook;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * Hard size cap for the unauthenticated {@code /api/**} surface (webhooks and
+ * workflow callbacks). Without it, anonymous callers could POST arbitrarily
+ * large JSON bodies and force full in-memory parsing before any secret check
+ * runs - a cheap memory/CPU DoS.
+ *
+ * <p>Requests with a declared {@code Content-Length} above the limit get a
+ * {@code 413}. Chunked requests (unknown length) are wrapped in a bounded
+ * input stream that aborts once the limit is exceeded.</p>
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class ApiPayloadSizeLimitFilter extends OncePerRequestFilter {
+
+    private final long maxBodyBytes;
+
+    public ApiPayloadSizeLimitFilter(
+            @Value("${giteabot.api.max-body-bytes:2097152}") long maxBodyBytes) {
+        this.maxBodyBytes = maxBodyBytes;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !request.getRequestURI().startsWith("/api/");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        long declared = request.getContentLengthLong();
+        if (declared > maxBodyBytes) {
+            response.sendError(HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE, "Payload too large");
+            return;
+        }
+        if (declared < 0) {
+            // Chunked transfer encoding - enforce the cap while reading.
+            request = new BoundedBodyRequestWrapper(request, maxBodyBytes);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private static final class BoundedBodyRequestWrapper extends HttpServletRequestWrapper {
+        private final long maxBytes;
+
+        BoundedBodyRequestWrapper(HttpServletRequest request, long maxBytes) {
+            super(request);
+            this.maxBytes = maxBytes;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new BoundedServletInputStream(super.getInputStream(), maxBytes);
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return new BufferedReader(new InputStreamReader(getInputStream(), getCharacterEncoding()));
+        }
+    }
+
+    private static final class BoundedServletInputStream extends ServletInputStream {
+        private final InputStream delegate;
+        private final long maxBytes;
+        private long consumed;
+
+        BoundedServletInputStream(InputStream delegate, long maxBytes) {
+            this.delegate = delegate;
+            this.maxBytes = maxBytes;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = delegate.read();
+            if (value != -1) {
+                count(1);
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int read = delegate.read(b, off, len);
+            if (read > 0) {
+                count(read);
+            }
+            return read;
+        }
+
+        private void count(long n) throws IOException {
+            consumed += n;
+            if (consumed > maxBytes) {
+                throw new IOException("Request body exceeds the configured limit of " + maxBytes + " bytes");
+            }
+        }
+
+        @Override
+        public boolean isFinished() {
+            try {
+                return delegate.available() == 0;
+            } catch (IOException e) {
+                return true;
+            }
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener readListener) {
+            // async reads not used here
+        }
+    }
+}

--- a/src/main/java/org/remus/giteabot/webhook/UnifiedWebhookController.java
+++ b/src/main/java/org/remus/giteabot/webhook/UnifiedWebhookController.java
@@ -1,5 +1,6 @@
 package org.remus.giteabot.webhook;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.admin.Bot;
@@ -39,16 +40,22 @@ public class UnifiedWebhookController {
     private final GitHubWebhookHandler gitHubHandler;
     private final BitbucketWebhookHandler bitbucketHandler;
     private final GitLabWebhookHandler gitLabHandler;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Unified webhook endpoint. Routes to the appropriate handler based on
      * the bot's Git integration type.
      *
+     * <p>The raw body is required (not a pre-parsed map) so the provider
+     * signature can be verified over the exact bytes before any JSON parsing
+     * happens.</p>
+     *
      * @param webhookSecret the bot's unique webhook secret (URL path)
      * @param xGitHubEvent  GitHub event type header (optional)
      * @param xGitLabEvent  GitLab event type header (optional)
      * @param xEventKey     Bitbucket event key header (optional)
-     * @param payload       the raw webhook payload
+     * @param headers       all request headers (for signature verification)
+     * @param rawBody       the raw webhook payload bytes
      * @return response indicating the result of webhook processing
      */
     @PostMapping("/{webhookSecret}")
@@ -57,13 +64,28 @@ public class UnifiedWebhookController {
             @RequestHeader(value = "X-GitHub-Event", required = false) String xGitHubEvent,
             @RequestHeader(value = "X-Gitlab-Event", required = false) String xGitLabEvent,
             @RequestHeader(value = "X-Event-Key", required = false) String xEventKey,
-            @RequestBody Map<String, Object> payload) {
+            @RequestHeader Map<String, String> headers,
+            @RequestBody byte[] rawBody) {
 
         return botService.findByWebhookSecret(webhookSecret)
                 .map(bot -> {
                     if (!bot.isEnabled()) {
                         log.debug("Bot '{}' is disabled, ignoring webhook", bot.getName());
                         return ResponseEntity.ok("bot disabled");
+                    }
+                    // Optional second factor: provider signature over the raw body.
+                    String signingSecret = botService.getDecryptedWebhookSigningSecret(bot);
+                    if (!WebhookSignatureVerifier.isValid(
+                            bot.getGitIntegration().getProviderType(), signingSecret, headers, rawBody)) {
+                        log.warn("Invalid webhook signature for bot '{}' from {}",
+                                bot.getName(), headers.getOrDefault("x-forwarded-for", "?"));
+                        return ResponseEntity.status(401).body("invalid signature");
+                    }
+                    Map<String, Object> payload;
+                    try {
+                        payload = objectMapper.readValue(rawBody, Map.class);
+                    } catch (Exception e) {
+                        return ResponseEntity.badRequest().body("invalid JSON payload");
                     }
                     botService.incrementWebhookCallCount(bot);
                     return routeToHandler(bot, xGitHubEvent, xGitLabEvent, xEventKey, payload);
@@ -97,4 +119,3 @@ public class UnifiedWebhookController {
         };
     }
 }
-

--- a/src/main/java/org/remus/giteabot/webhook/UnifiedWebhookController.java
+++ b/src/main/java/org/remus/giteabot/webhook/UnifiedWebhookController.java
@@ -1,5 +1,6 @@
 package org.remus.giteabot.webhook;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -83,7 +84,7 @@ public class UnifiedWebhookController {
                     }
                     Map<String, Object> payload;
                     try {
-                        payload = objectMapper.readValue(rawBody, Map.class);
+                        payload = objectMapper.readValue(rawBody, new TypeReference<>() {});
                     } catch (Exception e) {
                         return ResponseEntity.badRequest().body("invalid JSON payload");
                     }

--- a/src/main/java/org/remus/giteabot/webhook/WebhookSignatureVerifier.java
+++ b/src/main/java/org/remus/giteabot/webhook/WebhookSignatureVerifier.java
@@ -1,0 +1,107 @@
+package org.remus.giteabot.webhook;
+
+import lombok.extern.slf4j.Slf4j;
+import org.remus.giteabot.repository.RepositoryType;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Verifies the authenticity of inbound provider webhooks against an optional
+ * per-bot signing secret (configured in the bot settings and at the git
+ * provider).
+ *
+ * <ul>
+ *   <li>GitHub: {@code X-Hub-Signature-256: sha256=<hex-hmac>}</li>
+ *   <li>Gitea: {@code X-Gitea-Signature: <hex-hmac>}</li>
+ *   <li>GitLab: {@code X-Gitlab-Token: <secret>} (plain equality)</li>
+ *   <li>Bitbucket Cloud: {@code X-Hub-Signature: sha256=<hex-hmac>}</li>
+ * </ul>
+ *
+ * All comparisons are constant-time. When a signing secret is configured for a
+ * bot, requests without a valid signature are rejected - the URL path secret
+ * then acts as routing/second factor only.
+ */
+@Slf4j
+public final class WebhookSignatureVerifier {
+
+    private WebhookSignatureVerifier() {
+    }
+
+    /**
+     * Verifies the request. Returns {@code true} when no signing secret is
+     * configured (backwards compatible) or the signature matches.
+     *
+     * @param providerType the bot's git provider
+     * @param signingSecret the configured shared secret (may be {@code null}/blank)
+     * @param headers request headers (keys are matched case-insensitively)
+     * @param rawBody the exact request body bytes
+     */
+    public static boolean isValid(RepositoryType providerType, String signingSecret,
+                                  Map<String, String> headers, byte[] rawBody) {
+        if (signingSecret == null || signingSecret.isBlank()) {
+            return true;
+        }
+        String expected;
+        String actual;
+        switch (providerType) {
+            case GITHUB -> {
+                expected = "sha256=" + hmacSha256Hex(signingSecret, rawBody);
+                actual = header(headers, "X-Hub-Signature-256");
+            }
+            case GITEA -> {
+                expected = hmacSha256Hex(signingSecret, rawBody);
+                actual = header(headers, "X-Gitea-Signature");
+            }
+            case GITLAB -> {
+                expected = signingSecret;
+                actual = header(headers, "X-Gitlab-Token");
+            }
+            case BITBUCKET -> {
+                expected = "sha256=" + hmacSha256Hex(signingSecret, rawBody);
+                actual = header(headers, "X-Hub-Signature");
+            }
+            default -> {
+                log.warn("Webhook signature verification not implemented for provider {}", providerType);
+                return false;
+            }
+        }
+        return constantTimeEquals(expected, actual);
+    }
+
+    private static String hmacSha256Hex(String secret, byte[] body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(body));
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to compute webhook signature", e);
+        }
+    }
+
+    private static String header(Map<String, String> headers, String name) {
+        if (headers == null) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getKey() != null && entry.getKey().toLowerCase(Locale.ROOT).equals(name.toLowerCase(Locale.ROOT))) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean constantTimeEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                expected.trim().getBytes(StandardCharsets.UTF_8),
+                actual.trim().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/resources/db/migration/h2/V40__webhook_signing_secret.sql
+++ b/src/main/resources/db/migration/h2/V40__webhook_signing_secret.sql
@@ -1,0 +1,5 @@
+-- Optional per-bot webhook signing secret used to verify the provider's
+-- webhook signature (X-Hub-Signature-256 / X-Gitea-Signature / X-Gitlab-Token)
+-- in addition to the URL path secret. Stored AES-GCM-encrypted by the app.
+
+ALTER TABLE bots ADD COLUMN IF NOT EXISTS webhook_signing_secret VARCHAR(1000);

--- a/src/main/resources/db/migration/postgresql/V40__webhook_signing_secret.sql
+++ b/src/main/resources/db/migration/postgresql/V40__webhook_signing_secret.sql
@@ -1,0 +1,5 @@
+-- Optional per-bot webhook signing secret used to verify the provider's
+-- webhook signature (X-Hub-Signature-256 / X-Gitea-Signature / X-Gitlab-Token)
+-- in addition to the URL path secret. Stored AES-GCM-encrypted by the app.
+
+ALTER TABLE bots ADD COLUMN IF NOT EXISTS webhook_signing_secret VARCHAR(1000);

--- a/src/main/resources/templates/bots/form.html
+++ b/src/main/resources/templates/bots/form.html
@@ -212,6 +212,20 @@
                             </div>
                         </div>
 
+                        <div class="col-12">
+                            <label for="webhookSigningSecret" class="form-label">Webhook signing secret <span class="text-secondary">(optional, recommended)</span></label>
+                            <input type="password" class="form-control font-monospace" id="webhookSigningSecret"
+                                   name="webhookSigningSecret" autocomplete="new-password"
+                                   th:placeholder="${bot.id != null and bot.webhookSigningSecret != null} ? 'configured - leave blank to keep' : 'shared secret configured at the provider'"/>
+                            <div class="form-text">
+                                When set, the bot verifies the provider's webhook signature
+                                (<code>X-Hub-Signature-256</code> for GitHub, <code>X-Gitea-Signature</code> for Gitea,
+                                <code>X-Gitlab-Token</code> for GitLab, <code>X-Hub-Signature</code> for Bitbucket)
+                                and rejects forged events. Configure the same secret in the provider's webhook settings.
+                                Stored encrypted. <strong>Highly recommended for public repositories.</strong>
+                            </div>
+                        </div>
+
                         <div class="col-md-6">
                             <div class="form-check form-switch mt-3">
                                 <input class="form-check-input" type="checkbox" id="enabled"

--- a/src/main/resources/templates/bots/form.html
+++ b/src/main/resources/templates/bots/form.html
@@ -214,9 +214,17 @@
 
                         <div class="col-12">
                             <label for="webhookSigningSecret" class="form-label">Webhook signing secret <span class="text-secondary">(optional, recommended)</span></label>
-                            <input type="password" class="form-control font-monospace" id="webhookSigningSecret"
-                                   name="webhookSigningSecret" autocomplete="new-password"
-                                   th:placeholder="${bot.id != null and bot.webhookSigningSecret != null} ? 'configured - leave blank to keep' : 'shared secret configured at the provider'"/>
+                            <div class="input-group">
+                                <input type="password" class="form-control font-monospace" id="webhookSigningSecret"
+                                       name="webhookSigningSecret" autocomplete="new-password"
+                                       th:placeholder="${bot.id != null and bot.webhookSigningSecret != null} ? 'configured - leave blank to keep' : 'shared secret configured at the provider'"/>
+                                <button class="btn btn-outline-secondary" type="button" id="clearWebhookSigningSecretBtn"
+                                        th:if="${bot.id != null and bot.webhookSigningSecret != null}"
+                                        title="Remove the stored signing secret">
+                                    <i class="bi bi-trash"></i> Clear
+                                </button>
+                            </div>
+                            <input type="hidden" id="clearWebhookSigningSecret" name="clearWebhookSigningSecret" value="false"/>
                             <div class="form-text">
                                 When set, the bot verifies the provider's webhook signature
                                 (<code>X-Hub-Signature-256</code> for GitHub, <code>X-Gitea-Signature</code> for Gitea,
@@ -788,6 +796,19 @@
                             alert(error.message);
                         });
                 });
+
+                // ---- Webhook signing secret: remember that the operator wants
+                // it removed on save (an empty field alone means "keep the
+                // stored value", so we need an explicit marker). ----
+                const clearWebhookSigningSecretBtn = document.getElementById('clearWebhookSigningSecretBtn');
+                if (clearWebhookSigningSecretBtn) {
+                    clearWebhookSigningSecretBtn.addEventListener('click', function() {
+                        const secretInput = document.getElementById('webhookSigningSecret');
+                        secretInput.value = '';
+                        secretInput.placeholder = 'signing secret will be removed on save';
+                        document.getElementById('clearWebhookSigningSecret').value = 'true';
+                    });
+                }
             });
             /*]]>*/
         </script>

--- a/src/test/java/org/remus/giteabot/ArchitectureTest.java
+++ b/src/test/java/org/remus/giteabot/ArchitectureTest.java
@@ -43,15 +43,34 @@ class ArchitectureTest {
             noClasses().that().resideOutsideOfPackage(BASE + ".webhook")
                     .should().dependOnClassesThat().resideInAPackage(BASE + ".webhook");
 
-    /** MVC controllers are entry points and must not be used by other classes. */
+    /** MVC controllers are entry points and must not be used by other classes.
+     * Classes nested inside a controller (e.g. lambdas capturing {@code this},
+     * compiled to synthetic inner classes whose constructor takes the enclosing
+     * controller) are exempt — that dependency is compiler-generated. */
     @ArchTest
     static final ArchRule controllers_are_not_depended_upon =
             noClasses()
+                    .that(DescribedPredicate.describe("are not nested inside a controller",
+                            origin -> !isNestedInsideController(origin)))
                     .should().dependOnClassesThat(
-                            DescribedPredicate.describe("are controllers",
-                                    target -> !target.isAnnotation()
-                                            && (target.isAnnotatedWith(org.springframework.stereotype.Controller.class)
-                                            || target.isAnnotatedWith(org.springframework.web.bind.annotation.RestController.class))));
+                            DescribedPredicate.describe("are controllers", ArchitectureTest::isController));
+
+    private static boolean isController(com.tngtech.archunit.core.domain.JavaClass javaClass) {
+        return !javaClass.isAnnotation()
+                && (javaClass.isAnnotatedWith(org.springframework.stereotype.Controller.class)
+                || javaClass.isAnnotatedWith(org.springframework.web.bind.annotation.RestController.class));
+    }
+
+    private static boolean isNestedInsideController(com.tngtech.archunit.core.domain.JavaClass javaClass) {
+        var enclosing = javaClass.getEnclosingClass();
+        while (enclosing.isPresent()) {
+            if (isController(enclosing.get())) {
+                return true;
+            }
+            enclosing = enclosing.get().getEnclosingClass();
+        }
+        return false;
+    }
 
     /** The {@code config} package is a leaf and must not depend on any feature package. */
     @ArchTest

--- a/src/test/java/org/remus/giteabot/admin/BotControllerTest.java
+++ b/src/test/java/org/remus/giteabot/admin/BotControllerTest.java
@@ -148,14 +148,14 @@ class BotControllerTest {
                 mock(org.remus.giteabot.prworkflow.config.DeploymentTargetService.class));
 
         Bot bot = new Bot();
-        String view = controller.save(bot, 1L, 2L, 3L, null, 4L, null, 9L, null,
+        String view = controller.save(bot, 1L, 2L, 3L, null, 4L, null, 9L, null, false,
                 new org.springframework.ui.ExtendedModelMap(),
                 new org.springframework.web.servlet.mvc.support.RedirectAttributesModelMap());
 
         assertEquals("redirect:/bots", view);
         org.junit.jupiter.api.Assertions.assertSame(issueConfiguration,
                 bot.getIssueWorkflowConfiguration());
-        org.mockito.Mockito.verify(botService).save(bot);
+        org.mockito.Mockito.verify(botService).save(bot, false);
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/admin/BotServiceTest.java
+++ b/src/test/java/org/remus/giteabot/admin/BotServiceTest.java
@@ -102,6 +102,34 @@ class BotServiceTest {
     }
 
     @Test
+    void save_clearsStoredWebhookSigningSecretWhenClearRequested() {
+        Bot bot = newBotWithDefaultToolConfig();
+        bot.setId(1L);
+        bot.setWebhookSigningSecret(" ");
+        when(botRepository.save(any(Bot.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Bot result = botService.save(bot, true);
+
+        assertNull(result.getWebhookSigningSecret());
+        verify(encryptionService, never()).encrypt(anyString());
+        verify(botRepository, never()).findById(1L);
+    }
+
+    @Test
+    void save_newSecretWinsEvenWhenClearRequested() {
+        Bot bot = newBotWithDefaultToolConfig();
+        bot.setId(1L);
+        bot.setWebhookSigningSecret("plain-signing-secret");
+        when(encryptionService.encrypt("plain-signing-secret")).thenReturn("encrypted-signing-secret");
+        when(botRepository.save(any(Bot.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Bot result = botService.save(bot, true);
+
+        assertEquals("encrypted-signing-secret", result.getWebhookSigningSecret());
+        verify(encryptionService).encrypt("plain-signing-secret");
+    }
+
+    @Test
     void getDecryptedWebhookSigningSecret_decryptsStoredSecret() {
         Bot bot = new Bot();
         bot.setWebhookSigningSecret("encrypted-signing-secret");

--- a/src/test/java/org/remus/giteabot/admin/BotServiceTest.java
+++ b/src/test/java/org/remus/giteabot/admin/BotServiceTest.java
@@ -24,6 +24,9 @@ class BotServiceTest {
     @Mock
     private BotToolConfigurationRepository botToolConfigurationRepository;
 
+    @Mock
+    private EncryptionService encryptionService;
+
     @InjectMocks
     private BotService botService;
 
@@ -67,6 +70,47 @@ class BotServiceTest {
         Bot result = botService.save(bot);
 
         assertEquals("existing-secret", result.getWebhookSecret());
+    }
+
+    @Test
+    void save_encryptsWebhookSigningSecret() {
+        Bot bot = newBotWithDefaultToolConfig();
+        bot.setWebhookSigningSecret("plain-signing-secret");
+        when(encryptionService.encrypt("plain-signing-secret")).thenReturn("encrypted-signing-secret");
+        when(botRepository.save(any(Bot.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Bot result = botService.save(bot);
+
+        assertEquals("encrypted-signing-secret", result.getWebhookSigningSecret());
+        verify(encryptionService).encrypt("plain-signing-secret");
+    }
+
+    @Test
+    void save_keepsStoredWebhookSigningSecretWhenUpdateLeavesItBlank() {
+        Bot bot = newBotWithDefaultToolConfig();
+        bot.setId(1L);
+        bot.setWebhookSigningSecret(" ");
+        Bot existing = new Bot();
+        existing.setWebhookSigningSecret("encrypted-signing-secret");
+        when(botRepository.findById(1L)).thenReturn(Optional.of(existing));
+        when(botRepository.save(any(Bot.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Bot result = botService.save(bot);
+
+        assertEquals("encrypted-signing-secret", result.getWebhookSigningSecret());
+        verify(encryptionService, never()).encrypt(anyString());
+    }
+
+    @Test
+    void getDecryptedWebhookSigningSecret_decryptsStoredSecret() {
+        Bot bot = new Bot();
+        bot.setWebhookSigningSecret("encrypted-signing-secret");
+        when(encryptionService.decrypt("encrypted-signing-secret")).thenReturn("plain-signing-secret");
+
+        String result = botService.getDecryptedWebhookSigningSecret(bot);
+
+        assertEquals("plain-signing-secret", result);
+        verify(encryptionService).decrypt("encrypted-signing-secret");
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilterTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilterTest.java
@@ -1,0 +1,66 @@
+package org.remus.giteabot.webhook;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ApiPayloadSizeLimitFilterTest {
+
+    @Test
+    void doFilter_rejectsDeclaredPayloadAboveTheLimit() throws Exception {
+        ApiPayloadSizeLimitFilter filter = new ApiPayloadSizeLimitFilter(10);
+        MockHttpServletRequest request = apiRequest("01234567890");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean();
+
+        filter.doFilter(request, response, (ignoredRequest, ignoredResponse) -> chainCalled.set(true));
+
+        assertEquals(413, response.getStatus());
+        assertFalse(chainCalled.get());
+    }
+
+    @Test
+    void doFilter_allowsDeclaredPayloadAtTheLimit() throws Exception {
+        ApiPayloadSizeLimitFilter filter = new ApiPayloadSizeLimitFilter(10);
+        MockHttpServletRequest request = apiRequest("0123456789");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AtomicBoolean chainCalled = new AtomicBoolean();
+
+        filter.doFilter(request, response, (ignoredRequest, ignoredResponse) -> chainCalled.set(true));
+
+        assertTrue(chainCalled.get());
+    }
+
+    @Test
+    void doFilter_stopsChunkedPayloadAboveTheLimit() throws Exception {
+        ApiPayloadSizeLimitFilter filter = new ApiPayloadSizeLimitFilter(10);
+        MockHttpServletRequest request = new MockHttpServletRequest() {
+            @Override
+            public long getContentLengthLong() {
+                return -1;
+            }
+        };
+        request.setRequestURI("/api/webhook/test-secret");
+        request.setContent("01234567890".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (wrappedRequest, ignoredResponse) -> assertThrows(
+                IOException.class, () -> wrappedRequest.getInputStream().readAllBytes()));
+    }
+
+    private static MockHttpServletRequest apiRequest(String content) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setRequestURI("/api/webhook/test-secret");
+        request.setContent(content.getBytes(StandardCharsets.UTF_8));
+        return request;
+    }
+}

--- a/src/test/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilterTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/ApiPayloadSizeLimitFilterTest.java
@@ -41,6 +41,22 @@ class ApiPayloadSizeLimitFilterTest {
     }
 
     @Test
+    void doFilter_rejectsPayloadUnderServletContextPath() throws Exception {
+        ApiPayloadSizeLimitFilter filter = new ApiPayloadSizeLimitFilter(10);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("/bot");
+        request.setRequestURI("/bot/api/webhook/test-secret");
+        request.setContent("01234567890".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, (ignoredRequest, ignoredResponse) -> {
+            throw new AssertionError("The filter must reject the oversized API request");
+        });
+
+        assertEquals(413, response.getStatus());
+    }
+
+    @Test
     void doFilter_stopsChunkedPayloadAboveTheLimit() throws Exception {
         ApiPayloadSizeLimitFilter filter = new ApiPayloadSizeLimitFilter(10);
         MockHttpServletRequest request = new MockHttpServletRequest() {

--- a/src/test/java/org/remus/giteabot/webhook/UnifiedWebhookControllerTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/UnifiedWebhookControllerTest.java
@@ -15,7 +15,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,6 +82,44 @@ class UnifiedWebhookControllerTest {
         verify(gitHubHandler).handleWebhook(eq(bot), eq("pull_request"), any(Map.class));
         verify(giteaHandler, never()).handleWebhook(any(), any());
         verify(bitbucketHandler, never()).handleWebhook(any(), any(), any());
+    }
+
+    @Test
+    void handleWebhook_githubBot_acceptsValidSignature() throws Exception {
+        Bot bot = createTestBot(RepositoryType.GITHUB);
+        String payload = "{\"action\":\"opened\",\"pull_request\":{\"number\":1}}";
+        when(botService.findByWebhookSecret("test-secret")).thenReturn(Optional.of(bot));
+        when(botService.getDecryptedWebhookSigningSecret(bot)).thenReturn("webhook-secret");
+        when(gitHubHandler.handleWebhook(eq(bot), eq("pull_request"), any())).thenReturn(ResponseEntity.ok("review triggered"));
+
+        mockMvc.perform(post("/api/webhook/test-secret")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-GitHub-Event", "pull_request")
+                        .header("X-Hub-Signature-256", "sha256=" + hmacSha256("webhook-secret", payload))
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(content().string("review triggered"));
+
+        verify(gitHubHandler).handleWebhook(eq(bot), eq("pull_request"), any(Map.class));
+    }
+
+    @Test
+    void handleWebhook_githubBot_rejectsInvalidSignatureBeforeDispatch() throws Exception {
+        Bot bot = createTestBot(RepositoryType.GITHUB);
+        bot.setWebhookSigningSecret("encrypted-signing-secret");
+        when(botService.findByWebhookSecret("test-secret")).thenReturn(Optional.of(bot));
+        when(botService.getDecryptedWebhookSigningSecret(bot)).thenReturn("webhook-secret");
+
+        mockMvc.perform(post("/api/webhook/test-secret")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header("X-GitHub-Event", "pull_request")
+                        .header("X-Hub-Signature-256", "sha256=invalid")
+                        .content("{\"action\":\"opened\",\"pull_request\":{\"number\":1}}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(content().string("invalid signature"));
+
+        verify(gitHubHandler, never()).handleWebhook(any(), any(), any());
+        verify(botService, never()).incrementWebhookCallCount(bot);
     }
 
     @Test
@@ -192,5 +234,14 @@ class UnifiedWebhookControllerTest {
 
         return bot;
     }
-}
 
+    private static String hmacSha256(String secret, String body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(body.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/org/remus/giteabot/webhook/WebhookSignatureVerifierTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/WebhookSignatureVerifierTest.java
@@ -1,0 +1,69 @@
+package org.remus.giteabot.webhook;
+
+import org.junit.jupiter.api.Test;
+import org.remus.giteabot.repository.RepositoryType;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WebhookSignatureVerifierTest {
+
+    private static final String SECRET = "webhook-secret";
+    private static final byte[] BODY = "{\"action\":\"opened\"}".getBytes(StandardCharsets.UTF_8);
+
+    @Test
+    void isValid_allowsUnsignedWebhooksWhenNoSigningSecretIsConfigured() {
+        assertTrue(WebhookSignatureVerifier.isValid(RepositoryType.GITHUB, null, Map.of(), BODY));
+        assertTrue(WebhookSignatureVerifier.isValid(RepositoryType.GITHUB, " ", Map.of(), BODY));
+    }
+
+    @Test
+    void isValid_acceptsGitHubSignatureCaseInsensitively() {
+        String signature = "sha256=" + hmacSha256(SECRET, BODY);
+
+        assertTrue(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITHUB, SECRET, Map.of("x-hub-signature-256", signature), BODY));
+    }
+
+    @Test
+    void isValid_acceptsGiteaSignature() {
+        assertTrue(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITEA, SECRET, Map.of("X-Gitea-Signature", hmacSha256(SECRET, BODY)), BODY));
+    }
+
+    @Test
+    void isValid_acceptsGitLabToken() {
+        assertTrue(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITLAB, SECRET, Map.of("X-Gitlab-Token", SECRET), BODY));
+    }
+
+    @Test
+    void isValid_acceptsBitbucketSignature() {
+        String signature = "sha256=" + hmacSha256(SECRET, BODY);
+
+        assertTrue(WebhookSignatureVerifier.isValid(
+                RepositoryType.BITBUCKET, SECRET, Map.of("X-Hub-Signature", signature), BODY));
+    }
+
+    @Test
+    void isValid_rejectsInvalidSignature() {
+        assertFalse(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITHUB, SECRET, Map.of("X-Hub-Signature-256", "sha256=invalid"), BODY));
+    }
+
+    private static String hmacSha256(String secret, byte[] body) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(body));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/org/remus/giteabot/webhook/WebhookSignatureVerifierTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/WebhookSignatureVerifierTest.java
@@ -57,6 +57,16 @@ class WebhookSignatureVerifierTest {
                 RepositoryType.GITHUB, SECRET, Map.of("X-Hub-Signature-256", "sha256=invalid"), BODY));
     }
 
+    @Test
+    void isValid_rejectsInvalidGiteaGitLabAndBitbucketValues() {
+        assertFalse(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITEA, SECRET, Map.of("X-Gitea-Signature", "invalid"), BODY));
+        assertFalse(WebhookSignatureVerifier.isValid(
+                RepositoryType.GITLAB, SECRET, Map.of("X-Gitlab-Token", "invalid"), BODY));
+        assertFalse(WebhookSignatureVerifier.isValid(
+                RepositoryType.BITBUCKET, SECRET, Map.of("X-Hub-Signature", "sha256=invalid"), BODY));
+    }
+
     private static String hmacSha256(String secret, byte[] body) {
         try {
             Mac mac = Mac.getInstance("HmacSHA256");

--- a/src/test/java/org/remus/giteabot/webhook/WebhookSigningSecretMigrationTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/WebhookSigningSecretMigrationTest.java
@@ -1,0 +1,45 @@
+package org.remus.giteabot.webhook;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class WebhookSigningSecretMigrationTest {
+
+    private static final String URL = "jdbc:h2:mem:webhook-signing-secret-migration-test;DB_CLOSE_DELAY=-1";
+    private static final String LOCATIONS = "filesystem:src/main/resources/db/migration/h2";
+
+    private static Flyway flyway(String target) {
+        return Flyway.configure()
+                .dataSource(URL, "sa", "")
+                .locations(LOCATIONS)
+                .target(target)
+                .load();
+    }
+
+    @Test
+    void v40_acceptsAnExistingSigningSecretColumn() throws Exception {
+        flyway("39").migrate();
+
+        try (Connection connection = DriverManager.getConnection(URL, "sa", "");
+             Statement statement = connection.createStatement()) {
+            statement.execute("ALTER TABLE bots ADD COLUMN webhook_signing_secret VARCHAR(1000)");
+        }
+
+        flyway("40").migrate();
+
+        try (Connection connection = DriverManager.getConnection(URL, "sa", "");
+             Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS "
+                     + "WHERE TABLE_NAME = 'BOTS' AND COLUMN_NAME = 'WEBHOOK_SIGNING_SECRET'")) {
+            result.next();
+            assertEquals(1, result.getInt(1));
+        }
+    }
+}

--- a/src/test/java/org/remus/giteabot/webhook/WebhookSigningSecretMigrationTest.java
+++ b/src/test/java/org/remus/giteabot/webhook/WebhookSigningSecretMigrationTest.java
@@ -12,29 +12,44 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class WebhookSigningSecretMigrationTest {
 
-    private static final String URL = "jdbc:h2:mem:webhook-signing-secret-migration-test;DB_CLOSE_DELAY=-1";
+    private static final String NORMAL_UPGRADE_URL =
+            "jdbc:h2:mem:webhook-signing-secret-normal-upgrade-test;DB_CLOSE_DELAY=-1";
+    private static final String EXISTING_COLUMN_URL =
+            "jdbc:h2:mem:webhook-signing-secret-existing-column-test;DB_CLOSE_DELAY=-1";
     private static final String LOCATIONS = "filesystem:src/main/resources/db/migration/h2";
 
-    private static Flyway flyway(String target) {
+    private static Flyway flyway(String url, String target) {
         return Flyway.configure()
-                .dataSource(URL, "sa", "")
+                .dataSource(url, "sa", "")
                 .locations(LOCATIONS)
                 .target(target)
                 .load();
     }
 
     @Test
-    void v40_acceptsAnExistingSigningSecretColumn() throws Exception {
-        flyway("39").migrate();
+    void v40_addsTheSigningSecretColumn() throws Exception {
+        flyway(NORMAL_UPGRADE_URL, "39").migrate();
+        flyway(NORMAL_UPGRADE_URL, "40").migrate();
 
-        try (Connection connection = DriverManager.getConnection(URL, "sa", "");
+        assertSigningSecretColumn(NORMAL_UPGRADE_URL);
+    }
+
+    @Test
+    void v40_acceptsAnExistingSigningSecretColumn() throws Exception {
+        flyway(EXISTING_COLUMN_URL, "39").migrate();
+
+        try (Connection connection = DriverManager.getConnection(EXISTING_COLUMN_URL, "sa", "");
              Statement statement = connection.createStatement()) {
             statement.execute("ALTER TABLE bots ADD COLUMN webhook_signing_secret VARCHAR(1000)");
         }
 
-        flyway("40").migrate();
+        flyway(EXISTING_COLUMN_URL, "40").migrate();
 
-        try (Connection connection = DriverManager.getConnection(URL, "sa", "");
+        assertSigningSecretColumn(EXISTING_COLUMN_URL);
+    }
+
+    private static void assertSigningSecretColumn(String url) throws Exception {
+        try (Connection connection = DriverManager.getConnection(url, "sa", "");
              Statement statement = connection.createStatement();
              ResultSet result = statement.executeQuery("SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS "
                      + "WHERE TABLE_NAME = 'BOTS' AND COLUMN_NAME = 'WEBHOOK_SIGNING_SECRET'")) {


### PR DESCRIPTION
## What was done and why?

- Adds optional per-bot webhook signing secrets and verifies GitHub, Gitea, GitLab, and Bitbucket webhook authentication before processing callbacks.
- Stores signing secrets with the existing encryption service and keeps provider setup documentation alongside the implementation.
- Enforces the configured API request-body limit before webhook processing.
- Makes the V40 signing-secret schema migrations idempotent for H2 and PostgreSQL.
- Adds focused provider, migration, and payload-limit regression coverage.

## Testing

- Build and verify CI
- Focused webhook, migration, and payload-limit regression tests
- Git whitespace validation

### AI use

- Initial implementation used KIMI K3; the split, hardening, and review used OpenCode (gpt-5.6-terra).