### PR TITLE
harden agent workspace boundaries

### DIFF
--- a/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.agent.tools.ToolCatalog;
 import org.remus.giteabot.config.AgentConfigProperties;
-import org.remus.giteabot.util.WorkspacePaths;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -1258,7 +1257,7 @@ public class ToolExecutionService {
 
     private Path resolveWorkspacePath(Path workspaceDir, String relativePath) throws IOException {
         try {
-            return WorkspacePaths.resolveInsideWorkspace(workspaceDir, relativePath);
+            return org.remus.giteabot.util.WorkspacePaths.resolveInsideWorkspace(workspaceDir, relativePath);
         } catch (IllegalArgumentException e) {
             throw new IOException(e.getMessage(), e);
         }

--- a/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -568,8 +569,8 @@ public class ToolExecutionService {
         List<String> matches = new ArrayList<>();
         try (Stream<Path> stream = Files.walk(basePath, MAX_SEARCH_DEPTH)) {
             List<Path> files = stream
-                    .filter(path -> !isGitInternalPath(path))
-                    .filter(Files::isRegularFile)
+                    .filter(this::isVisibleWorkspacePath)
+                    .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
                     .filter(this::isReasonableTextFile)
                     .sorted()
                     .toList();
@@ -688,8 +689,8 @@ public class ToolExecutionService {
         try (Stream<Path> stream = Files.walk(basePath)) {
             List<String> matches = stream
                     .filter(path -> !path.equals(basePath))
-                    .filter(path -> !isGitInternalPath(path))
-                    .filter(Files::isRegularFile)
+                    .filter(this::isVisibleWorkspacePath)
+                    .filter(path -> Files.isRegularFile(path, LinkOption.NOFOLLOW_LINKS))
                     .sorted()
                     .map(workspaceDir::relativize)
                     .map(Path::toString)
@@ -899,7 +900,7 @@ public class ToolExecutionService {
 
         try (Stream<Path> stream = Files.walk(basePath, maxDepth)) {
             List<String> lines = stream
-                    .filter(path -> !isGitInternalPath(path))
+                    .filter(this::isVisibleWorkspacePath)
                     .sorted(Comparator.naturalOrder())
                     .map(path -> formatTreeEntry(basePath, path))
                     .toList();
@@ -1266,11 +1267,16 @@ public class ToolExecutionService {
     /** True when any path segment belongs to the repository's internal Git metadata. */
     private boolean isGitInternalPath(Path path) {
         for (Path segment : path) {
-            if (".git".equals(segment.toString())) {
+            if (".git".equalsIgnoreCase(segment.toString())) {
                 return true;
             }
         }
         return false;
+    }
+
+    /** Symlinks can point outside the workspace even when recursive walks do not follow directories. */
+    private boolean isVisibleWorkspacePath(Path path) {
+        return !isGitInternalPath(path) && !Files.isSymbolicLink(path);
     }
 
     private ToolResult executeCommand(Path workspaceDir, String[] command) {

--- a/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.agent.tools.ToolCatalog;
 import org.remus.giteabot.config.AgentConfigProperties;
+import org.remus.giteabot.util.WorkspacePaths;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -567,6 +568,7 @@ public class ToolExecutionService {
         List<String> matches = new ArrayList<>();
         try (Stream<Path> stream = Files.walk(basePath, MAX_SEARCH_DEPTH)) {
             List<Path> files = stream
+                    .filter(path -> !isGitInternalPath(path))
                     .filter(Files::isRegularFile)
                     .filter(this::isReasonableTextFile)
                     .sorted()
@@ -686,6 +688,7 @@ public class ToolExecutionService {
         try (Stream<Path> stream = Files.walk(basePath)) {
             List<String> matches = stream
                     .filter(path -> !path.equals(basePath))
+                    .filter(path -> !isGitInternalPath(path))
                     .filter(Files::isRegularFile)
                     .sorted()
                     .map(workspaceDir::relativize)
@@ -896,6 +899,7 @@ public class ToolExecutionService {
 
         try (Stream<Path> stream = Files.walk(basePath, maxDepth)) {
             List<String> lines = stream
+                    .filter(path -> !isGitInternalPath(path))
                     .sorted(Comparator.naturalOrder())
                     .map(path -> formatTreeEntry(basePath, path))
                     .toList();
@@ -1252,21 +1256,21 @@ public class ToolExecutionService {
 
 
     private Path resolveWorkspacePath(Path workspaceDir, String relativePath) throws IOException {
-        // Stage 1: normalize() resolves any ".." segments without touching the filesystem.
-        Path normalized = workspaceDir.resolve(relativePath).normalize();
-        if (!normalized.startsWith(workspaceDir.normalize())) {
-            throw new IOException("Path escapes workspace: " + relativePath);
+        try {
+            return WorkspacePaths.resolveInsideWorkspace(workspaceDir, relativePath);
+        } catch (IllegalArgumentException e) {
+            throw new IOException(e.getMessage(), e);
         }
-        // Stage 2: if the target already exists, re-check after symlink resolution so that
-        // a symlink inside the workspace pointing outside is also caught.
-        if (Files.exists(normalized)) {
-            Path realBase = workspaceDir.toRealPath();
-            Path realPath = normalized.toRealPath();
-            if (!realPath.startsWith(realBase)) {
-                throw new IOException("Path escapes workspace via symlink: " + relativePath);
+    }
+
+    /** True when any path segment belongs to the repository's internal Git metadata. */
+    private boolean isGitInternalPath(Path path) {
+        for (Path segment : path) {
+            if (".git".equals(segment.toString())) {
+                return true;
             }
         }
-        return normalized;
+        return false;
     }
 
     private ToolResult executeCommand(Path workspaceDir, String[] command) {

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -31,25 +31,34 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class WorkspaceService {
 
-
     /**
      * Clones a repository workspace. When a branch-based shallow clone fails and
      * {@code prNumber} is non-null, falls back to cloning the default branch then
      * fetching {@code refs/pull/<prNumber>/head} (GitHub/Gitea fork-safe ref).
+     *
+     * <p>Credentials are never embedded in the remote URL: the clone/push use a
+     * git credential-store file placed <em>outside</em> the workspace, so the
+     * token never lands in {@code .git/config}, in git error output, or in the
+     * agent's file/search tools.</p>
      */
     public WorkspaceResult prepareWorkspace(String owner, String repo, String branch,
                                             String cloneBaseUrl, String token, Long prNumber) {
+        Path credentialsFile = null;
         try {
             Path tempDir = Files.createTempDirectory("agent-workspace-");
             log.info("Cloning repository to {} for workspace", tempDir);
 
-            String cloneUrl = buildCloneUrl(owner, repo, cloneBaseUrl, token);
+            String cloneUrl = buildCloneUrl(owner, repo, cloneBaseUrl);
+            credentialsFile = createCredentialsFile(cloneBaseUrl, token, tempDir);
+            String[] credentialConfig = credentialConfigArgs(credentialsFile);
             CommandResult cloneResult = runCommand(tempDir.getParent().toFile(),
-                    new String[]{"git", "clone", "--depth", "1", "--branch", branch,
-                            cloneUrl, tempDir.getFileName().toString()},
+                    withCredentialConfig(credentialConfig,
+                            "clone", "--depth", "1", "--branch", branch,
+                            cloneUrl, tempDir.getFileName().toString()),
                     60);
 
             if (cloneResult.success()) {
+                persistCredentialHelper(tempDir, credentialsFile);
                 return WorkspaceResult.success(tempDir);
             }
 
@@ -58,21 +67,28 @@ public class WorkspaceService {
                 log.info("Branch clone failed, falling back to PR head ref for PR #{}: {}",
                         prNumber, cloneResult.output());
                 deleteDirectory(tempDir);
+                deleteCredentialsFile(credentialsFile);
                 tempDir = Files.createTempDirectory("agent-workspace-");
+                credentialsFile = createCredentialsFile(cloneBaseUrl, token, tempDir);
+                credentialConfig = credentialConfigArgs(credentialsFile);
 
                 CommandResult defaultCloneResult = runCommand(tempDir.getParent().toFile(),
-                        new String[]{"git", "clone", "--depth", "1",
-                                cloneUrl, tempDir.getFileName().toString()},
+                        withCredentialConfig(credentialConfig,
+                                "clone", "--depth", "1",
+                                cloneUrl, tempDir.getFileName().toString()),
                         60);
 
                 if (!defaultCloneResult.success()) {
                     log.error("Fallback clone (default branch) also failed: {}",
                             defaultCloneResult.output());
                     deleteDirectory(tempDir);
+                    deleteCredentialsFile(credentialsFile);
                     return WorkspaceResult.failure(
                             "Failed to clone repository (branch: " + cloneResult.output()
                                     + "; default branch: " + defaultCloneResult.output() + ")");
                 }
+
+                persistCredentialHelper(tempDir, credentialsFile);
 
                 CommandResult fetchResult = runCommand(tempDir.toFile(),
                         new String[]{"git", "fetch", "origin",
@@ -83,6 +99,7 @@ public class WorkspaceService {
                     log.error("Failed to fetch PR head ref for PR #{}: {}", prNumber,
                             fetchResult.output());
                     deleteDirectory(tempDir);
+                    deleteCredentialsFile(credentialsFile);
                     return WorkspaceResult.failure(
                             "Failed to fetch PR head ref for PR #" + prNumber + ": "
                                     + fetchResult.output());
@@ -95,6 +112,7 @@ public class WorkspaceService {
                     log.error("Failed to checkout FETCH_HEAD for PR #{}: {}", prNumber,
                             checkoutResult.output());
                     deleteDirectory(tempDir);
+                    deleteCredentialsFile(credentialsFile);
                     return WorkspaceResult.failure(
                             "Failed to checkout FETCH_HEAD for PR #" + prNumber + ": "
                                     + checkoutResult.output());
@@ -106,10 +124,12 @@ public class WorkspaceService {
             // No fallback — report the original clone error
             log.error("Failed to clone repository: {}", cloneResult.output());
             deleteDirectory(tempDir);
+            deleteCredentialsFile(credentialsFile);
             return WorkspaceResult.failure("Failed to clone repository: " + cloneResult.output());
 
         } catch (IOException e) {
             log.error("Failed to prepare workspace: {}", e.getMessage());
+            deleteCredentialsFile(credentialsFile);
             return WorkspaceResult.failure("Failed to prepare workspace: " + e.getMessage());
         }
     }
@@ -260,12 +280,14 @@ public class WorkspaceService {
 
 
     /**
-     * Cleans up a workspace directory by deleting it recursively.
+     * Cleans up a workspace directory by deleting it recursively. Also removes
+     * the sibling git-credentials file created by {@link #prepareWorkspace}.
      */
     public void cleanupWorkspace(Path workspaceDir) {
         if (workspaceDir != null) {
             try {
                 deleteDirectory(workspaceDir);
+                deleteCredentialsFile(credentialsFileFor(workspaceDir));
                 log.debug("Cleaned up workspace: {}", workspaceDir);
             } catch (IOException e) {
                 log.warn("Failed to clean up workspace {}: {}", workspaceDir, e.getMessage());
@@ -275,9 +297,11 @@ public class WorkspaceService {
 
     // ---- internal helpers ------------------------------------------------
 
-    String buildCloneUrl(String owner, String repo, String cloneBaseUrl, String token) {
-        // For local filesystem paths (used in tests and local development),
-        // pass through as-is — git handles bare directory paths natively.
+    /**
+     * Builds the credential-free clone URL. For local filesystem paths (used in
+     * tests and local development), passes through as-is.
+     */
+    String buildCloneUrl(String owner, String repo, String cloneBaseUrl) {
         if (cloneBaseUrl.startsWith("file://") || cloneBaseUrl.startsWith("/")) {
             return cloneBaseUrl;
         }
@@ -288,8 +312,91 @@ public class WorkspaceService {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
 
-        // oauth2:TOKEN format works for GitLab, GitHub, Gitea, and Bitbucket
-        return String.format("%s://oauth2:%s@%s/%s/%s.git", protocol, token, baseUrl, owner, repo);
+        return String.format("%s://%s/%s/%s.git", protocol, baseUrl, owner, repo);
+    }
+
+    /**
+     * Writes a git credential-store file <em>outside</em> the workspace
+     * (sibling of the workspace dir, named after it) so the token is never
+     * stored inside the cloned repository. Returns {@code null} for local
+     * paths or blank tokens.
+     */
+    Path createCredentialsFile(String cloneBaseUrl, String token, Path workspaceDir)
+            throws IOException {
+        if (token == null || token.isBlank()
+                || cloneBaseUrl.startsWith("file://") || cloneBaseUrl.startsWith("/")) {
+            return null;
+        }
+        String protocol = cloneBaseUrl.startsWith("https://") ? "https" : "http";
+        String baseUrl = cloneBaseUrl.replaceFirst("https?://", "");
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+        String host = baseUrl.contains("/") ? baseUrl.substring(0, baseUrl.indexOf('/')) : baseUrl;
+
+        Path credentialsFile = credentialsFileFor(workspaceDir);
+        Files.writeString(credentialsFile, protocol + "://oauth2:" + token + "@" + host + "\n");
+        // Best-effort owner-only permissions.
+        credentialsFile.toFile().setReadable(false, false);
+        credentialsFile.toFile().setWritable(false, false);
+        credentialsFile.toFile().setReadable(true, true);
+        credentialsFile.toFile().setWritable(true, true);
+        return credentialsFile;
+    }
+
+    /** The credential-store file associated with a workspace directory. */
+    private Path credentialsFileFor(Path workspaceDir) {
+        return workspaceDir.resolveSibling(workspaceDir.getFileName() + ".credentials");
+    }
+
+    /**
+     * git {@code -c} arguments that authenticate via the credential-store file
+     * (used for the initial clone, before the repo-local config exists).
+     */
+    private String[] credentialConfigArgs(Path credentialsFile) {
+        if (credentialsFile == null) {
+            return new String[0];
+        }
+        return new String[]{
+                "-c", "credential.helper=",
+                "-c", "credential.helper=store --file=" + credentialsFile.toAbsolutePath()};
+    }
+
+    private String[] withCredentialConfig(String[] credentialConfig, String... gitArgs) {
+        String[] command = new String[1 + credentialConfig.length + gitArgs.length];
+        command[0] = "git";
+        System.arraycopy(credentialConfig, 0, command, 1, credentialConfig.length);
+        System.arraycopy(gitArgs, 0, command, 1 + credentialConfig.length, gitArgs.length);
+        return command;
+    }
+
+    /**
+     * Persists the credential helper into the cloned repo's local config so
+     * later fetches/pushes authenticate without any environment state.
+     */
+    private void persistCredentialHelper(Path workspaceDir, Path credentialsFile) {
+        if (credentialsFile == null) {
+            return;
+        }
+        runCommand(workspaceDir.toFile(),
+                new String[]{"git", "config", "--local", "credential.helper", ""}, 10);
+        runCommand(workspaceDir.toFile(),
+                new String[]{"git", "config", "--local", "--add", "credential.helper",
+                        "store --file=" + credentialsFile.toAbsolutePath()}, 10);
+    }
+
+    /**
+     * Deletes the credential-store file belonging to a workspace, if present.
+     * Called from {@link #cleanupWorkspace(Path)}.
+     */
+    private void deleteCredentialsFile(Path credentialsFile) {
+        if (credentialsFile != null) {
+            try {
+                Files.deleteIfExists(credentialsFile);
+            } catch (IOException e) {
+                log.warn("Failed to delete git credentials file {}: {}", credentialsFile, e.getMessage());
+            }
+        }
     }
 
     private CommandResult runCommand(File workDir, String[] command, int timeoutSeconds) {
@@ -338,4 +445,3 @@ public class WorkspaceService {
         }
     }
 }
-

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class WorkspaceService {
 
-    private static final String REPOSITORY_DIRECTORY_NAME = "repository";
+    static final String REPOSITORY_DIRECTORY_NAME = "repository";
     private static final String WORKSPACE_ROOT_MARKER = ".agent-workspace";
     private static final Set<PosixFilePermission> OWNER_DIRECTORY_PERMISSIONS = Set.of(
             PosixFilePermission.OWNER_READ,
@@ -81,14 +81,15 @@ public class WorkspaceService {
      */
     public WorkspaceResult prepareWorkspace(String owner, String repo, String branch,
                                             String cloneBaseUrl, String token, Long prNumber) {
-        Path workspaceDir = null;
-        Path credentialsFile = null;
+        WorkspaceSetup setup = null;
         try {
-            workspaceDir = createWorkspaceDirectory();
+            setup = createWorkspaceSetup();
+            Path workspaceDir = setup.workspaceDir();
             log.info("Cloning repository to {} for workspace", workspaceDir);
 
             String cloneUrl = buildCloneUrl(owner, repo, cloneBaseUrl);
-            credentialsFile = createCredentialsFile(cloneBaseUrl, token, workspaceDir);
+            Path credentialsFile = createCredentialsFile(cloneBaseUrl, token, workspaceDir);
+            setup.setCredentialsFile(credentialsFile);
             String[] credentialConfig = credentialConfigArgs(credentialsFile);
             CommandResult cloneResult = runCommand(workspaceDir.getParent().toFile(),
                     withCredentialConfig(credentialConfig,
@@ -105,9 +106,15 @@ public class WorkspaceService {
             if (prNumber != null) {
                 log.info("Branch clone failed, falling back to PR head ref for PR #{}: {}",
                         prNumber, cloneResult.output());
-                cleanupWorkspace(workspaceDir);
-                workspaceDir = createWorkspaceDirectory();
+                // Tear down the failed attempt (private parent AND its credential
+                // file) before starting the retry, so a partial directory deletion
+                // can never orphan the token file — the setup holder keeps both
+                // references alive until both are deleted.
+                cleanupWorkspace(setup);
+                setup = createWorkspaceSetup();
+                workspaceDir = setup.workspaceDir();
                 credentialsFile = createCredentialsFile(cloneBaseUrl, token, workspaceDir);
+                setup.setCredentialsFile(credentialsFile);
                 credentialConfig = credentialConfigArgs(credentialsFile);
 
                 CommandResult defaultCloneResult = runCommand(workspaceDir.getParent().toFile(),
@@ -119,7 +126,7 @@ public class WorkspaceService {
                 if (!defaultCloneResult.success()) {
                     log.error("Fallback clone (default branch) also failed: {}",
                             defaultCloneResult.output());
-                    cleanupWorkspace(workspaceDir);
+                    cleanupWorkspace(setup);
                     return WorkspaceResult.failure(
                             "Failed to clone repository (branch: " + cloneResult.output()
                                     + "; default branch: " + defaultCloneResult.output() + ")");
@@ -135,7 +142,7 @@ public class WorkspaceService {
                 if (!fetchResult.success()) {
                     log.error("Failed to fetch PR head ref for PR #{}: {}", prNumber,
                             fetchResult.output());
-                    cleanupWorkspace(workspaceDir);
+                    cleanupWorkspace(setup);
                     return WorkspaceResult.failure(
                             "Failed to fetch PR head ref for PR #" + prNumber + ": "
                                     + fetchResult.output());
@@ -147,7 +154,7 @@ public class WorkspaceService {
                 if (!checkoutResult.success()) {
                     log.error("Failed to checkout FETCH_HEAD for PR #{}: {}", prNumber,
                             checkoutResult.output());
-                    cleanupWorkspace(workspaceDir);
+                    cleanupWorkspace(setup);
                     return WorkspaceResult.failure(
                             "Failed to checkout FETCH_HEAD for PR #" + prNumber + ": "
                                     + checkoutResult.output());
@@ -158,13 +165,12 @@ public class WorkspaceService {
 
             // No fallback — report the original clone error
             log.error("Failed to clone repository: {}", cloneResult.output());
-            cleanupWorkspace(workspaceDir);
+            cleanupWorkspace(setup);
             return WorkspaceResult.failure("Failed to clone repository: " + cloneResult.output());
 
         } catch (IOException e) {
             log.error("Failed to prepare workspace: {}", e.getMessage());
-            cleanupWorkspace(workspaceDir);
-            deleteCredentialsFile(credentialsFile);
+            cleanupWorkspace(setup);
             return WorkspaceResult.failure("Failed to prepare workspace: " + e.getMessage());
         }
     }
@@ -320,15 +326,31 @@ public class WorkspaceService {
      * the external git credential-store file created by {@link #prepareWorkspace}.
      */
     public void cleanupWorkspace(Path workspaceDir) {
-        if (workspaceDir != null) {
-            deleteCredentialsFile(credentialsByWorkspace.remove(workspaceKey(workspaceDir)));
-            try {
-                Path workspaceRoot = workspaceRootFor(workspaceDir);
-                deleteDirectory(workspaceRoot != null ? workspaceRoot : workspaceDir);
-                log.debug("Cleaned up workspace: {}", workspaceDir);
-            } catch (IOException e) {
-                log.warn("Failed to clean up workspace {}: {}", workspaceDir, e.getMessage());
-            }
+        if (workspaceDir == null) {
+            return;
+        }
+        Path workspaceRoot = workspaceRootFor(workspaceDir);
+        WorkspaceSetup setup = new WorkspaceSetup(workspaceRoot != null ? workspaceRoot : workspaceDir);
+        setup.setCredentialsFile(credentialsByWorkspace.remove(workspaceKey(workspaceDir)));
+        cleanupWorkspace(setup);
+    }
+
+    /**
+     * Cleans up a whole {@link WorkspaceSetup}: the credential-store file and
+     * the private temporary parent are deleted together. Keeping both
+     * references in one holder guarantees that no retry path can drop the
+     * credential file after a partial directory deletion.
+     */
+    void cleanupWorkspace(WorkspaceSetup setup) {
+        if (setup == null) {
+            return;
+        }
+        deleteCredentialsFile(setup.credentialsFile());
+        try {
+            deleteDirectory(setup.workspaceRoot());
+            log.debug("Cleaned up workspace: {}", setup.workspaceDir());
+        } catch (IOException e) {
+            log.warn("Failed to clean up workspace {}: {}", setup.workspaceDir(), e.getMessage());
         }
     }
 
@@ -382,6 +404,16 @@ public class WorkspaceService {
 
     /** Creates a private temporary parent and returns its repository child path. */
     Path createWorkspaceDirectory() throws IOException {
+        return createWorkspaceSetup().workspaceDir();
+    }
+
+    /**
+     * Creates a new workspace attempt as a single {@link WorkspaceSetup} holding
+     * the private temporary parent (with its marker file) and, once created, the
+     * external credential-store file. The holder is the unit of cleanup, so both
+     * always travel together through retry and error paths.
+     */
+    WorkspaceSetup createWorkspaceSetup() throws IOException {
         Path workspaceRoot;
         if (workspaceBaseDir == null) {
             workspaceRoot = Files.createTempDirectory("agent-workspace-");
@@ -392,7 +424,7 @@ public class WorkspaceService {
         try {
             restrictToOwner(workspaceRoot, true);
             Files.createFile(workspaceRoot.resolve(WORKSPACE_ROOT_MARKER));
-            return workspaceRoot.resolve(REPOSITORY_DIRECTORY_NAME);
+            return new WorkspaceSetup(workspaceRoot);
         } catch (IOException e) {
             deleteDirectory(workspaceRoot);
             throw e;

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -43,6 +45,7 @@ public class WorkspaceService {
     private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS = Set.of(
             PosixFilePermission.OWNER_READ,
             PosixFilePermission.OWNER_WRITE);
+    private final ConcurrentMap<Path, Path> credentialsByWorkspace = new ConcurrentHashMap<>();
 
     /**
      * Clones a repository workspace. When a branch-based shallow clone fails and
@@ -72,7 +75,7 @@ public class WorkspaceService {
                     60);
 
             if (cloneResult.success()) {
-                persistCredentialHelper(workspaceDir, credentialsFile);
+                registerCredentialsFile(workspaceDir, credentialsFile);
                 return WorkspaceResult.success(workspaceDir);
             }
 
@@ -100,11 +103,11 @@ public class WorkspaceService {
                                     + "; default branch: " + defaultCloneResult.output() + ")");
                 }
 
-                persistCredentialHelper(workspaceDir, credentialsFile);
+                registerCredentialsFile(workspaceDir, credentialsFile);
 
                 CommandResult fetchResult = runCommand(workspaceDir.toFile(),
-                        new String[]{"git", "fetch", "origin",
-                                "refs/pull/" + prNumber + "/head"},
+                        withCredentialConfig(credentialConfigForWorkspace(workspaceDir),
+                                "fetch", "origin", "refs/pull/" + prNumber + "/head"),
                         60);
 
                 if (!fetchResult.success()) {
@@ -200,7 +203,8 @@ public class WorkspaceService {
         }
 
         CommandResult pushResult = runCommand(workspaceDir.toFile(),
-                new String[]{"git", "push", "origin", branchName}, 60);
+                withCredentialConfig(credentialConfigForWorkspace(workspaceDir),
+                        "push", "origin", branchName), 60);
         if (!pushResult.success()) {
             log.error("git push failed: {}", pushResult.output());
             return false;
@@ -295,6 +299,7 @@ public class WorkspaceService {
      */
     public void cleanupWorkspace(Path workspaceDir) {
         if (workspaceDir != null) {
+            deleteCredentialsFile(credentialsByWorkspace.remove(workspaceKey(workspaceDir)));
             try {
                 Path workspaceRoot = workspaceRootFor(workspaceDir);
                 deleteDirectory(workspaceRoot != null ? workspaceRoot : workspaceDir);
@@ -404,7 +409,7 @@ public class WorkspaceService {
 
     /**
      * git {@code -c} arguments that authenticate via the credential-store file
-     * (used for the initial clone, before the repo-local config exists).
+     * used for every authenticated Git command.
      */
     private String[] credentialConfigArgs(Path credentialsFile) {
         if (credentialsFile == null) {
@@ -423,19 +428,19 @@ public class WorkspaceService {
         return command;
     }
 
-    /**
-     * Persists the credential helper into the cloned repo's local config so
-     * later fetches/pushes authenticate without any environment state.
-     */
-    private void persistCredentialHelper(Path workspaceDir, Path credentialsFile) {
+    void registerCredentialsFile(Path workspaceDir, Path credentialsFile) {
         if (credentialsFile == null) {
             return;
         }
-        runCommand(workspaceDir.toFile(),
-                new String[]{"git", "config", "--local", "credential.helper", ""}, 10);
-        runCommand(workspaceDir.toFile(),
-                new String[]{"git", "config", "--local", "--add", "credential.helper",
-                        "store --file=" + credentialsFile.toAbsolutePath()}, 10);
+        credentialsByWorkspace.put(workspaceKey(workspaceDir), credentialsFile);
+    }
+
+    String[] credentialConfigForWorkspace(Path workspaceDir) {
+        return credentialConfigArgs(credentialsByWorkspace.get(workspaceKey(workspaceDir)));
+    }
+
+    private Path workspaceKey(Path workspaceDir) {
+        return workspaceDir.toAbsolutePath().normalize();
     }
 
     /** Deletes a credential-store file after a failed workspace setup. */

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -16,6 +16,7 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -47,6 +48,11 @@ public class WorkspaceService {
     private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS = Set.of(
             PosixFilePermission.OWNER_READ,
             PosixFilePermission.OWNER_WRITE);
+    private static final List<String> GIT_ENVIRONMENT_ALLOWLIST = List.of(
+            "PATH", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR", "TMP", "TEMP",
+            "SystemRoot", "windir", "COMSPEC", "PATHEXT",
+            "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy",
+            "GIT_SSL_CAINFO", "GIT_SSL_CAPATH", "SSL_CERT_FILE", "SSL_CERT_DIR");
     private final Path workspaceBaseDir;
     private final ConcurrentMap<Path, Path> credentialsByWorkspace = new ConcurrentHashMap<>();
 
@@ -477,10 +483,29 @@ public class WorkspaceService {
     }
 
     private CommandResult runCommand(File workDir, String[] command, int timeoutSeconds) {
+        Path disabledHooksDirectory = null;
+        Path emptyGlobalGitConfig = null;
         try {
-            ProcessBuilder pb = new ProcessBuilder(command);
+            // Git reads repository-controlled configuration after untrusted code ran in the workspace.
+            disabledHooksDirectory = Files.createTempDirectory("ai-git-bot-empty-hooks-");
+            emptyGlobalGitConfig = Files.createTempFile(disabledHooksDirectory, "global-", ".gitconfig");
+            List<String> gitCommand = new ArrayList<>(command.length + 7);
+            gitCommand.add(command[0]);
+            gitCommand.add("-c");
+            gitCommand.add("core.hooksPath=" + disabledHooksDirectory.toAbsolutePath().normalize());
+            gitCommand.add("-c");
+            gitCommand.add("core.fsmonitor=false");
+            gitCommand.add("-c");
+            gitCommand.add("credential.helper=");
+            for (int index = 1; index < command.length; index++) {
+                gitCommand.add(command[index]);
+            }
+            ProcessBuilder pb = new ProcessBuilder(gitCommand);
             pb.directory(workDir);
             pb.redirectErrorStream(true);
+            scrubEnvironmentForGit(pb);
+            pb.environment().put("GIT_CONFIG_NOSYSTEM", "1");
+            pb.environment().put("GIT_CONFIG_GLOBAL", emptyGlobalGitConfig.toString());
 
             Process process = pb.start();
 
@@ -502,8 +527,40 @@ public class WorkspaceService {
             boolean success = process.exitValue() == 0;
             return new CommandResult(success, output.toString());
         } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
             log.error("Failed to run command: {}", e.getMessage());
             return new CommandResult(false, "Exception: " + e.getMessage());
+        } finally {
+            if (emptyGlobalGitConfig != null) {
+                try {
+                    Files.deleteIfExists(emptyGlobalGitConfig);
+                } catch (IOException e) {
+                    log.warn("Failed to remove empty global Git config {}: {}",
+                            emptyGlobalGitConfig, e.getMessage());
+                }
+            }
+            if (disabledHooksDirectory != null) {
+                try {
+                    Files.deleteIfExists(disabledHooksDirectory);
+                } catch (IOException e) {
+                    log.warn("Failed to remove empty Git hooks directory {}: {}",
+                            disabledHooksDirectory, e.getMessage());
+                }
+            }
+        }
+    }
+
+    /** Keeps credentials and application secrets out of Git subprocesses. */
+    private void scrubEnvironmentForGit(ProcessBuilder processBuilder) {
+        Map<String, String> environment = processBuilder.environment();
+        environment.clear();
+        for (String name : GIT_ENVIRONMENT_ALLOWLIST) {
+            String value = System.getenv(name);
+            if (value != null) {
+                environment.put(name, value);
+            }
         }
     }
 

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -8,10 +8,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -31,6 +34,16 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class WorkspaceService {
 
+    private static final String REPOSITORY_DIRECTORY_NAME = "repository";
+    private static final String WORKSPACE_ROOT_MARKER = ".agent-workspace";
+    private static final Set<PosixFilePermission> OWNER_DIRECTORY_PERMISSIONS = Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE);
+    private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS = Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE);
+
     /**
      * Clones a repository workspace. When a branch-based shallow clone fails and
      * {@code prNumber} is non-null, falls back to cloning the default branch then
@@ -43,54 +56,53 @@ public class WorkspaceService {
      */
     public WorkspaceResult prepareWorkspace(String owner, String repo, String branch,
                                             String cloneBaseUrl, String token, Long prNumber) {
+        Path workspaceDir = null;
         Path credentialsFile = null;
         try {
-            Path tempDir = Files.createTempDirectory("agent-workspace-");
-            log.info("Cloning repository to {} for workspace", tempDir);
+            workspaceDir = createWorkspaceDirectory();
+            log.info("Cloning repository to {} for workspace", workspaceDir);
 
             String cloneUrl = buildCloneUrl(owner, repo, cloneBaseUrl);
-            credentialsFile = createCredentialsFile(cloneBaseUrl, token, tempDir);
+            credentialsFile = createCredentialsFile(cloneBaseUrl, token, workspaceDir);
             String[] credentialConfig = credentialConfigArgs(credentialsFile);
-            CommandResult cloneResult = runCommand(tempDir.getParent().toFile(),
+            CommandResult cloneResult = runCommand(workspaceDir.getParent().toFile(),
                     withCredentialConfig(credentialConfig,
                             "clone", "--depth", "1", "--branch", branch,
-                            cloneUrl, tempDir.getFileName().toString()),
+                            cloneUrl, workspaceDir.getFileName().toString()),
                     60);
 
             if (cloneResult.success()) {
-                persistCredentialHelper(tempDir, credentialsFile);
-                return WorkspaceResult.success(tempDir);
+                persistCredentialHelper(workspaceDir, credentialsFile);
+                return WorkspaceResult.success(workspaceDir);
             }
 
             // Fork PR fallback: clone default branch → fetch PR head ref
             if (prNumber != null) {
                 log.info("Branch clone failed, falling back to PR head ref for PR #{}: {}",
                         prNumber, cloneResult.output());
-                deleteDirectory(tempDir);
-                deleteCredentialsFile(credentialsFile);
-                tempDir = Files.createTempDirectory("agent-workspace-");
-                credentialsFile = createCredentialsFile(cloneBaseUrl, token, tempDir);
+                cleanupWorkspace(workspaceDir);
+                workspaceDir = createWorkspaceDirectory();
+                credentialsFile = createCredentialsFile(cloneBaseUrl, token, workspaceDir);
                 credentialConfig = credentialConfigArgs(credentialsFile);
 
-                CommandResult defaultCloneResult = runCommand(tempDir.getParent().toFile(),
+                CommandResult defaultCloneResult = runCommand(workspaceDir.getParent().toFile(),
                         withCredentialConfig(credentialConfig,
                                 "clone", "--depth", "1",
-                                cloneUrl, tempDir.getFileName().toString()),
+                                cloneUrl, workspaceDir.getFileName().toString()),
                         60);
 
                 if (!defaultCloneResult.success()) {
                     log.error("Fallback clone (default branch) also failed: {}",
                             defaultCloneResult.output());
-                    deleteDirectory(tempDir);
-                    deleteCredentialsFile(credentialsFile);
+                    cleanupWorkspace(workspaceDir);
                     return WorkspaceResult.failure(
                             "Failed to clone repository (branch: " + cloneResult.output()
                                     + "; default branch: " + defaultCloneResult.output() + ")");
                 }
 
-                persistCredentialHelper(tempDir, credentialsFile);
+                persistCredentialHelper(workspaceDir, credentialsFile);
 
-                CommandResult fetchResult = runCommand(tempDir.toFile(),
+                CommandResult fetchResult = runCommand(workspaceDir.toFile(),
                         new String[]{"git", "fetch", "origin",
                                 "refs/pull/" + prNumber + "/head"},
                         60);
@@ -98,37 +110,35 @@ public class WorkspaceService {
                 if (!fetchResult.success()) {
                     log.error("Failed to fetch PR head ref for PR #{}: {}", prNumber,
                             fetchResult.output());
-                    deleteDirectory(tempDir);
-                    deleteCredentialsFile(credentialsFile);
+                    cleanupWorkspace(workspaceDir);
                     return WorkspaceResult.failure(
                             "Failed to fetch PR head ref for PR #" + prNumber + ": "
                                     + fetchResult.output());
                 }
 
-                CommandResult checkoutResult = runCommand(tempDir.toFile(),
+                CommandResult checkoutResult = runCommand(workspaceDir.toFile(),
                         new String[]{"git", "checkout", "-B", branch, "FETCH_HEAD"}, 15);
 
                 if (!checkoutResult.success()) {
                     log.error("Failed to checkout FETCH_HEAD for PR #{}: {}", prNumber,
                             checkoutResult.output());
-                    deleteDirectory(tempDir);
-                    deleteCredentialsFile(credentialsFile);
+                    cleanupWorkspace(workspaceDir);
                     return WorkspaceResult.failure(
                             "Failed to checkout FETCH_HEAD for PR #" + prNumber + ": "
                                     + checkoutResult.output());
                 }
 
-                return WorkspaceResult.success(tempDir);
+                return WorkspaceResult.success(workspaceDir);
             }
 
             // No fallback — report the original clone error
             log.error("Failed to clone repository: {}", cloneResult.output());
-            deleteDirectory(tempDir);
-            deleteCredentialsFile(credentialsFile);
+            cleanupWorkspace(workspaceDir);
             return WorkspaceResult.failure("Failed to clone repository: " + cloneResult.output());
 
         } catch (IOException e) {
             log.error("Failed to prepare workspace: {}", e.getMessage());
+            cleanupWorkspace(workspaceDir);
             deleteCredentialsFile(credentialsFile);
             return WorkspaceResult.failure("Failed to prepare workspace: " + e.getMessage());
         }
@@ -280,14 +290,14 @@ public class WorkspaceService {
 
 
     /**
-     * Cleans up a workspace directory by deleting it recursively. Also removes
-     * the sibling git-credentials file created by {@link #prepareWorkspace}.
+     * Cleans up a workspace directory and its private temporary parent, including
+     * the external git credential-store file created by {@link #prepareWorkspace}.
      */
     public void cleanupWorkspace(Path workspaceDir) {
         if (workspaceDir != null) {
             try {
-                deleteDirectory(workspaceDir);
-                deleteCredentialsFile(credentialsFileFor(workspaceDir));
+                Path workspaceRoot = workspaceRootFor(workspaceDir);
+                deleteDirectory(workspaceRoot != null ? workspaceRoot : workspaceDir);
                 log.debug("Cleaned up workspace: {}", workspaceDir);
             } catch (IOException e) {
                 log.warn("Failed to clean up workspace {}: {}", workspaceDir, e.getMessage());
@@ -316,10 +326,9 @@ public class WorkspaceService {
     }
 
     /**
-     * Writes a git credential-store file <em>outside</em> the workspace
-     * (sibling of the workspace dir, named after it) so the token is never
-     * stored inside the cloned repository. Returns {@code null} for local
-     * paths or blank tokens.
+     * Writes a git credential-store file <em>outside</em> the workspace in its
+     * private temporary parent, so the token is never stored inside the cloned
+     * repository. Returns {@code null} for local paths or blank tokens.
      */
     Path createCredentialsFile(String cloneBaseUrl, String token, Path workspaceDir)
             throws IOException {
@@ -334,19 +343,63 @@ public class WorkspaceService {
         }
         String host = baseUrl.contains("/") ? baseUrl.substring(0, baseUrl.indexOf('/')) : baseUrl;
 
-        Path credentialsFile = credentialsFileFor(workspaceDir);
+        Path workspaceRoot = workspaceRootFor(workspaceDir);
+        if (workspaceRoot == null) {
+            throw new IOException("Workspace does not have a private credential directory");
+        }
+        Path credentialsFile = Files.createTempFile(workspaceRoot, "credentials-", ".store");
+        restrictToOwner(credentialsFile, false);
         Files.writeString(credentialsFile, protocol + "://oauth2:" + token + "@" + host + "\n");
-        // Best-effort owner-only permissions.
-        credentialsFile.toFile().setReadable(false, false);
-        credentialsFile.toFile().setWritable(false, false);
-        credentialsFile.toFile().setReadable(true, true);
-        credentialsFile.toFile().setWritable(true, true);
         return credentialsFile;
     }
 
-    /** The credential-store file associated with a workspace directory. */
-    private Path credentialsFileFor(Path workspaceDir) {
-        return workspaceDir.resolveSibling(workspaceDir.getFileName() + ".credentials");
+    /** Creates a private temporary parent and returns its repository child path. */
+    Path createWorkspaceDirectory() throws IOException {
+        Path workspaceRoot = Files.createTempDirectory("agent-workspace-");
+        try {
+            restrictToOwner(workspaceRoot, true);
+            Files.createFile(workspaceRoot.resolve(WORKSPACE_ROOT_MARKER));
+            return workspaceRoot.resolve(REPOSITORY_DIRECTORY_NAME);
+        } catch (IOException e) {
+            deleteDirectory(workspaceRoot);
+            throw e;
+        }
+    }
+
+    /** Returns the private temporary parent created for the supplied workspace, if any. */
+    private Path workspaceRootFor(Path workspaceDir) {
+        if (workspaceDir == null || workspaceDir.getFileName() == null
+                || !REPOSITORY_DIRECTORY_NAME.equals(workspaceDir.getFileName().toString())) {
+            return null;
+        }
+        Path workspaceRoot = workspaceDir.getParent();
+        if (workspaceRoot == null) {
+            return null;
+        }
+        Path marker = workspaceRoot.resolve(WORKSPACE_ROOT_MARKER);
+        return Files.isRegularFile(marker, LinkOption.NOFOLLOW_LINKS) ? workspaceRoot : null;
+    }
+
+    /** Applies owner-only permissions where the host filesystem supports them. */
+    private void restrictToOwner(Path path, boolean directory) throws IOException {
+        try {
+            Files.setPosixFilePermissions(path,
+                    directory ? OWNER_DIRECTORY_PERMISSIONS : OWNER_FILE_PERMISSIONS);
+            return;
+        } catch (UnsupportedOperationException ignored) {
+            // Windows ACLs do not expose POSIX permissions through NIO.
+        }
+        File file = path.toFile();
+        file.setReadable(false, false);
+        file.setWritable(false, false);
+        if (directory) {
+            file.setExecutable(false, false);
+        }
+        file.setReadable(true, true);
+        file.setWritable(true, true);
+        if (directory) {
+            file.setExecutable(true, true);
+        }
     }
 
     /**
@@ -385,10 +438,7 @@ public class WorkspaceService {
                         "store --file=" + credentialsFile.toAbsolutePath()}, 10);
     }
 
-    /**
-     * Deletes the credential-store file belonging to a workspace, if present.
-     * Called from {@link #cleanupWorkspace(Path)}.
-     */
+    /** Deletes a credential-store file after a failed workspace setup. */
     private void deleteCredentialsFile(Path credentialsFile) {
         if (credentialsFile != null) {
             try {

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -1,6 +1,8 @@
 package org.remus.giteabot.agent.validation;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -45,7 +47,21 @@ public class WorkspaceService {
     private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS = Set.of(
             PosixFilePermission.OWNER_READ,
             PosixFilePermission.OWNER_WRITE);
+    private final Path workspaceBaseDir;
     private final ConcurrentMap<Path, Path> credentialsByWorkspace = new ConcurrentHashMap<>();
+
+    /** Creates a service that places workspaces under the system temporary directory. */
+    public WorkspaceService() {
+        this(null);
+    }
+
+    /** Creates a service that places private workspace parents under the configured directory. */
+    @Autowired
+    public WorkspaceService(@Value("${giteabot.workspaces.dir:#{null}}") String configuredDir) {
+        this.workspaceBaseDir = configuredDir == null || configuredDir.isBlank()
+                ? null
+                : Path.of(configuredDir).toAbsolutePath().normalize();
+    }
 
     /**
      * Clones a repository workspace. When a branch-based shallow clone fails and
@@ -360,7 +376,13 @@ public class WorkspaceService {
 
     /** Creates a private temporary parent and returns its repository child path. */
     Path createWorkspaceDirectory() throws IOException {
-        Path workspaceRoot = Files.createTempDirectory("agent-workspace-");
+        Path workspaceRoot;
+        if (workspaceBaseDir == null) {
+            workspaceRoot = Files.createTempDirectory("agent-workspace-");
+        } else {
+            Files.createDirectories(workspaceBaseDir);
+            workspaceRoot = Files.createTempDirectory(workspaceBaseDir, "agent-workspace-");
+        }
         try {
             restrictToOwner(workspaceRoot, true);
             Files.createFile(workspaceRoot.resolve(WORKSPACE_ROOT_MARKER));

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -14,6 +14,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -521,7 +522,7 @@ public class WorkspaceService {
             // Git reads repository-controlled configuration after untrusted code ran in the workspace.
             disabledHooksDirectory = Files.createTempDirectory("ai-git-bot-empty-hooks-");
             emptyGlobalGitConfig = Files.createTempFile(disabledHooksDirectory, "global-", ".gitconfig");
-            List<String> gitCommand = new ArrayList<>(command.length + 7);
+            List<String> gitCommand = new ArrayList<>(command.length + 6);
             gitCommand.add(command[0]);
             gitCommand.add("-c");
             gitCommand.add("core.hooksPath=" + disabledHooksDirectory.toAbsolutePath().normalize());
@@ -529,9 +530,7 @@ public class WorkspaceService {
             gitCommand.add("core.fsmonitor=false");
             gitCommand.add("-c");
             gitCommand.add("credential.helper=");
-            for (int index = 1; index < command.length; index++) {
-                gitCommand.add(command[index]);
-            }
+            gitCommand.addAll(Arrays.asList(command).subList(1, command.length));
             ProcessBuilder pb = new ProcessBuilder(gitCommand);
             pb.directory(workDir);
             pb.redirectErrorStream(true);

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceSetup.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceSetup.java
@@ -1,0 +1,44 @@
+package org.remus.giteabot.agent.validation;
+
+import java.nio.file.Path;
+
+/**
+ * Lifecycle holder of one workspace attempt: the private temporary parent
+ * ({@code workspaceRoot}) and the external git credential-store file created
+ * for it.
+ *
+ * <p>Both resources are created together with {@code WorkspaceSetup} and are
+ * cleaned up together via {@link WorkspaceService#cleanupWorkspace} — the
+ * credential-file reference can therefore never be dropped by a retry path
+ * (such as the branch-clone fallback in
+ * {@link WorkspaceService#prepareWorkspace}), even when a directory deletion
+ * only partially succeeds.</p>
+ */
+class WorkspaceSetup {
+
+    private final Path workspaceRoot;
+    private Path credentialsFile;
+
+    WorkspaceSetup(Path workspaceRoot) {
+        this.workspaceRoot = workspaceRoot;
+    }
+
+    /** The private temporary parent of this attempt (contains the marker file). */
+    Path workspaceRoot() {
+        return workspaceRoot;
+    }
+
+    /** The repository child directory that git clones into. */
+    Path workspaceDir() {
+        return workspaceRoot.resolve(WorkspaceService.REPOSITORY_DIRECTORY_NAME);
+    }
+
+    /** The external credential-store file of this attempt, or {@code null} if none. */
+    Path credentialsFile() {
+        return credentialsFile;
+    }
+
+    void setCredentialsFile(Path credentialsFile) {
+        this.credentialsFile = credentialsFile;
+    }
+}

--- a/src/main/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManager.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManager.java
@@ -2,6 +2,7 @@ package org.remus.giteabot.prworkflow.e2e.workspace;
 
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.prworkflow.e2e.E2eTestFramework;
+import org.remus.giteabot.util.WorkspacePaths;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -78,21 +79,7 @@ public class PrTestWorkspaceManager {
      * paths, {@code ..} traversal, symlink trickery).
      */
     public Path resolveInsideWorkspace(Path workspace, String relativePath) {
-        if (relativePath == null || relativePath.isBlank()) {
-            throw new IllegalArgumentException("relativePath must not be blank");
-        }
-        Path candidate = workspace.resolve(relativePath).toAbsolutePath().normalize();
-        Path normalizedWorkspace = workspace.toAbsolutePath().normalize();
-        if (!candidate.startsWith(normalizedWorkspace)) {
-            throw new IllegalArgumentException(
-                    "Path '" + relativePath + "' escapes the workspace");
-        }
-        // No symlink-following escape either.
-        if (Files.isSymbolicLink(candidate)) {
-            throw new IllegalArgumentException(
-                    "Path '" + relativePath + "' resolves to a symlink");
-        }
-        return candidate;
+        return WorkspacePaths.resolveInsideWorkspace(workspace, relativePath);
     }
 
     /**

--- a/src/main/java/org/remus/giteabot/prworkflow/i18n/I18nToolExecutor.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/i18n/I18nToolExecutor.java
@@ -120,18 +120,7 @@ public class I18nToolExecutor {
      * symlink trickery). Mirrors {@code ReadmeSyncToolExecutor.resolveInsideWorkspace}.
      */
     static Path resolveInsideWorkspace(Path workspace, String relativePath) {
-        if (relativePath == null || relativePath.isBlank()) {
-            throw new IllegalArgumentException("path must not be blank");
-        }
-        Path candidate = workspace.resolve(relativePath).toAbsolutePath().normalize();
-        Path normalizedWorkspace = workspace.toAbsolutePath().normalize();
-        if (!candidate.startsWith(normalizedWorkspace)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' escapes the workspace");
-        }
-        if (Files.isSymbolicLink(candidate)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' resolves to a symlink");
-        }
-        return candidate;
+        return org.remus.giteabot.util.WorkspacePaths.resolveInsideWorkspace(workspace, relativePath);
     }
 
     private static String requireString(Map<String, Object> args, String key) {

--- a/src/main/java/org/remus/giteabot/prworkflow/readmesync/ReadmeSyncToolExecutor.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/readmesync/ReadmeSyncToolExecutor.java
@@ -122,18 +122,7 @@ public class ReadmeSyncToolExecutor {
      * symlink trickery). Mirrors {@code UnitTestToolExecutor.resolveInsideWorkspace}.
      */
     static Path resolveInsideWorkspace(Path workspace, String relativePath) {
-        if (relativePath == null || relativePath.isBlank()) {
-            throw new IllegalArgumentException("path must not be blank");
-        }
-        Path candidate = workspace.resolve(relativePath).toAbsolutePath().normalize();
-        Path normalizedWorkspace = workspace.toAbsolutePath().normalize();
-        if (!candidate.startsWith(normalizedWorkspace)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' escapes the workspace");
-        }
-        if (Files.isSymbolicLink(candidate)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' resolves to a symlink");
-        }
-        return candidate;
+        return org.remus.giteabot.util.WorkspacePaths.resolveInsideWorkspace(workspace, relativePath);
     }
 
     private static String requireString(Map<String, Object> args, String key) {

--- a/src/main/java/org/remus/giteabot/prworkflow/unittest/tools/UnitTestToolExecutor.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/unittest/tools/UnitTestToolExecutor.java
@@ -130,18 +130,7 @@ public class UnitTestToolExecutor {
      * symlink trickery). Mirrors {@code PrTestWorkspaceManager.resolveInsideWorkspace}.
      */
     static Path resolveInsideWorkspace(Path workspace, String relativePath) {
-        if (relativePath == null || relativePath.isBlank()) {
-            throw new IllegalArgumentException("path must not be blank");
-        }
-        Path candidate = workspace.resolve(relativePath).toAbsolutePath().normalize();
-        Path normalizedWorkspace = workspace.toAbsolutePath().normalize();
-        if (!candidate.startsWith(normalizedWorkspace)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' escapes the workspace");
-        }
-        if (Files.isSymbolicLink(candidate)) {
-            throw new IllegalArgumentException("Path '" + relativePath + "' resolves to a symlink");
-        }
-        return candidate;
+        return org.remus.giteabot.util.WorkspacePaths.resolveInsideWorkspace(workspace, relativePath);
     }
 
     private static String requireString(Map<String, Object> args, String key) {

--- a/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
+++ b/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
@@ -1,0 +1,64 @@
+package org.remus.giteabot.util;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+
+/**
+ * Central workspace path guard for agent-facing file tools.
+ *
+ * <p>Resolves a caller-supplied relative path against the workspace root and
+ * rejects anything that would escape it - including {@code ..} traversal,
+ * absolute paths, and symlink tricks <em>in intermediate directories</em>
+ * (which a pull request can commit). The naive leaf-only {@code isSymbolicLink}
+ * check misses directory symlinks, so the nearest existing ancestor is
+ * resolved against its real path instead.</p>
+ */
+public final class WorkspacePaths {
+
+    private WorkspacePaths() {
+    }
+
+    /**
+     * Resolves {@code relativePath} inside {@code workspace}, rejecting escapes.
+     *
+     * @return the normalized absolute candidate path (may not exist yet)
+     * @throws IllegalArgumentException if the path is blank or escapes the workspace
+     */
+    public static Path resolveInsideWorkspace(Path workspace, String relativePath) {
+        if (relativePath == null || relativePath.isBlank()) {
+            throw new IllegalArgumentException("path must not be blank");
+        }
+        Path base = workspace.toAbsolutePath().normalize();
+        Path candidate = base.resolve(relativePath).normalize();
+        if (!candidate.startsWith(base)) {
+            throw new IllegalArgumentException("Path '" + relativePath + "' escapes the workspace");
+        }
+        for (Path segment : candidate) {
+            if (".git".equals(segment.toString())) {
+                throw new IllegalArgumentException("Access to .git internals is not allowed: " + relativePath);
+            }
+        }
+        if (Files.isSymbolicLink(candidate)) {
+            throw new IllegalArgumentException("Path '" + relativePath + "' resolves to a symlink");
+        }
+        // Symlink check on the nearest existing ancestor: catches directory
+        // symlinks (e.g. "docs -> /etc") committed by the PR, which the leaf
+        // check above cannot see when the target file does not exist yet.
+        try {
+            Path realBase = base.toRealPath();
+            Path existing = candidate;
+            while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+                existing = existing.getParent();
+            }
+            if (existing == null || !existing.toRealPath().startsWith(realBase)) {
+                throw new IllegalArgumentException(
+                        "Path '" + relativePath + "' escapes the workspace via symlinked directory");
+            }
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Cannot verify path '" + relativePath + "'", e);
+        }
+        return candidate;
+    }
+}

--- a/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
+++ b/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
@@ -14,6 +14,13 @@ import java.nio.file.Path;
  * (which a pull request can commit). The naive leaf-only {@code isSymbolicLink}
  * check misses directory symlinks, so the nearest existing ancestor is
  * resolved against its real path instead.</p>
+ *
+ * <p><strong>Deliberately strict on {@code ..}:</strong> any path containing a
+ * {@code ..} segment is rejected up front, even when normalizing it would stay
+ * inside the workspace (e.g. {@code src/../inside.txt}). Tool contracts should
+ * always pass resolved {@code absolute/normalized} paths or plain relative
+ * paths without parent references; callers seeing a "traversal" error for a
+ * semantically in-bounds path should fix the caller, not loosen this guard.</p>
  */
 public final class WorkspacePaths {
 

--- a/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
+++ b/src/main/java/org/remus/giteabot/util/WorkspacePaths.java
@@ -30,13 +30,23 @@ public final class WorkspacePaths {
         if (relativePath == null || relativePath.isBlank()) {
             throw new IllegalArgumentException("path must not be blank");
         }
+        Path requestedPath = Path.of(relativePath);
+        if (requestedPath.isAbsolute()) {
+            throw new IllegalArgumentException("Path must be relative: " + relativePath);
+        }
+        for (Path segment : requestedPath) {
+            if ("..".equals(segment.toString())) {
+                throw new IllegalArgumentException(
+                        "Path '" + relativePath + "' escapes the workspace via traversal");
+            }
+        }
         Path base = workspace.toAbsolutePath().normalize();
-        Path candidate = base.resolve(relativePath).normalize();
+        Path candidate = base.resolve(requestedPath).normalize();
         if (!candidate.startsWith(base)) {
             throw new IllegalArgumentException("Path '" + relativePath + "' escapes the workspace");
         }
         for (Path segment : candidate) {
-            if (".git".equals(segment.toString())) {
+            if (".git".equalsIgnoreCase(segment.toString())) {
                 throw new IllegalArgumentException("Access to .git internals is not allowed: " + relativePath);
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -23,6 +23,8 @@ agent.context.max-single-issue-comment-chars=${AGENT_CONTEXT_MAX_SINGLE_ISSUE_CO
 
 # Agent Validation (iterative error correction)
 agent.validation.enabled=${AGENT_VALIDATION_ENABLED:true}
+# Optional host-visible root for private agent workspace parents.
+giteabot.workspaces.dir=${GITEABOT_WORKSPACES_DIR:}
 # Agent budget limits (to prevent infinite loops and excessive API usage)
 agent.budget.max-context-rounds=${AGENT_BUDGET_MAX_CONTENT_ROUNDS:10}
 agent.budget.max-rounds=${AGENT_BUDGET_MAX_ROUNDS:20}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,10 +21,11 @@ agent.context.max-issue-comments-chars=${AGENT_CONTEXT_MAX_ISSUE_COMMENTS_CHARS:
 agent.context.max-single-issue-comment-chars=${AGENT_CONTEXT_MAX_SINGLE_ISSUE_COMMENT_CHARS:4000}
 # agent.allowed-repos=owner/repo1,owner/repo2
 
-# Agent Validation (iterative error correction)
-agent.validation.enabled=${AGENT_VALIDATION_ENABLED:true}
 # Optional host-visible root for private agent workspace parents.
 giteabot.workspaces.dir=${GITEABOT_WORKSPACES_DIR:}
+
+# Agent Validation (iterative error correction)
+agent.validation.enabled=${AGENT_VALIDATION_ENABLED:true}
 # Agent budget limits (to prevent infinite loops and excessive API usage)
 agent.budget.max-context-rounds=${AGENT_BUDGET_MAX_CONTENT_ROUNDS:10}
 agent.budget.max-rounds=${AGENT_BUDGET_MAX_ROUNDS:20}

--- a/src/test/java/org/remus/giteabot/agent/validation/ToolExecutionServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/ToolExecutionServiceTest.java
@@ -177,11 +177,14 @@ class ToolExecutionServiceTest {
         Files.writeString(tempDir.resolve(".git/config"), "token=should-not-be-visible");
 
         ToolResult catResult = service.executeContextTool(tempDir, "cat", List.of(".git/config"));
+        ToolResult caseVariantResult = service.executeContextTool(tempDir, "cat", List.of(".GIT/config"));
         ToolResult searchResult = service.executeContextTool(tempDir, "rg",
                 List.of("should-not-be-visible", "."));
 
         assertThat(catResult.success()).isFalse();
         assertThat(catResult.error()).contains("Access to .git internals is not allowed");
+        assertThat(caseVariantResult.success()).isFalse();
+        assertThat(caseVariantResult.error()).contains("Access to .git internals is not allowed");
         assertThat(searchResult.success()).isTrue();
         assertThat(searchResult.output()).doesNotContain(".git/config");
     }
@@ -199,6 +202,25 @@ class ToolExecutionServiceTest {
 
         assertThat(result.success()).isFalse();
         assertThat(result.error()).contains("symlinked directory");
+    }
+
+    @Test
+    void executeContextTool_skipsLeafSymlinksDuringRecursiveOperations() throws IOException {
+        Path workspace = tempDir.resolve("workspace");
+        Path outside = tempDir.resolve("outside");
+        Files.createDirectories(workspace);
+        Files.createDirectories(outside);
+        Files.writeString(outside.resolve("secret.txt"), "host-only-secret");
+        Files.createSymbolicLink(workspace.resolve("linked-secret.txt"), outside.resolve("secret.txt"));
+
+        ToolResult searchResult = service.executeContextTool(workspace, "rg", List.of("host-only-secret", "."));
+        ToolResult findResult = service.executeContextTool(workspace, "find", List.of("*", "."));
+        ToolResult treeResult = service.executeContextTool(workspace, "tree", List.of(".", "1"));
+
+        assertThat(searchResult.success()).isTrue();
+        assertThat(searchResult.output()).startsWith("No matches found");
+        assertThat(findResult.output()).doesNotContain("linked-secret.txt");
+        assertThat(treeResult.output()).doesNotContain("linked-secret.txt");
     }
 
     // ---- File tool tests ----

--- a/src/test/java/org/remus/giteabot/agent/validation/ToolExecutionServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/ToolExecutionServiceTest.java
@@ -171,6 +171,36 @@ class ToolExecutionServiceTest {
         assertThat(result.output()).isEqualTo("src/main/java/org/example/BotWebhookService.java");
     }
 
+    @Test
+    void executeContextTool_rejectsGitInternalsAndSkipsThemDuringSearch() throws IOException {
+        Files.createDirectories(tempDir.resolve(".git"));
+        Files.writeString(tempDir.resolve(".git/config"), "token=should-not-be-visible");
+
+        ToolResult catResult = service.executeContextTool(tempDir, "cat", List.of(".git/config"));
+        ToolResult searchResult = service.executeContextTool(tempDir, "rg",
+                List.of("should-not-be-visible", "."));
+
+        assertThat(catResult.success()).isFalse();
+        assertThat(catResult.error()).contains("Access to .git internals is not allowed");
+        assertThat(searchResult.success()).isTrue();
+        assertThat(searchResult.output()).doesNotContain(".git/config");
+    }
+
+    @Test
+    void executeContextTool_rejectsPathThroughSymlinkedDirectory() throws IOException {
+        Path workspace = tempDir.resolve("workspace");
+        Path outside = tempDir.resolve("outside");
+        Files.createDirectories(workspace);
+        Files.createDirectories(outside);
+        Files.writeString(outside.resolve("secret.txt"), "should-not-be-visible");
+        Files.createSymbolicLink(workspace.resolve("linked"), outside);
+
+        ToolResult result = service.executeContextTool(workspace, "cat", List.of("linked/secret.txt"));
+
+        assertThat(result.success()).isFalse();
+        assertThat(result.error()).contains("symlinked directory");
+    }
+
     // ---- File tool tests ----
 
     @Test

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -70,14 +70,31 @@ class WorkspaceServiceTest {
     @Test
     void buildCloneUrl_http() {
         String url = workspaceService.buildCloneUrl("owner", "repo",
-                "http://git.example.com", "mytoken");
-        assertThat(url).isEqualTo("http://oauth2:mytoken@git.example.com/owner/repo.git");
+                "http://git.example.com");
+        assertThat(url).isEqualTo("http://git.example.com/owner/repo.git");
     }
     @Test
     void buildCloneUrl_https_trailingSlash() {
         String url = workspaceService.buildCloneUrl("owner", "repo",
-                "https://git.example.com/", "tok");
-        assertThat(url).isEqualTo("https://oauth2:tok@git.example.com/owner/repo.git");
+                "https://git.example.com/");
+        assertThat(url).isEqualTo("https://git.example.com/owner/repo.git");
+    }
+
+    @Test
+    void createCredentialsFile_keepsTokenOutsideWorkspaceAndCleanupRemovesIt() throws IOException {
+        Path workspace = tempDir.resolve("workspace");
+        Files.createDirectories(workspace);
+
+        Path credentials = workspaceService.createCredentialsFile(
+                "https://git.example.com", "test-token", workspace);
+
+        assertThat(credentials).isEqualTo(tempDir.resolve("workspace.credentials"));
+        assertThat(credentials).isNotEqualTo(workspace.resolve(".git-credentials"));
+        assertThat(Files.readString(credentials)).isEqualTo("https://oauth2:test-token@git.example.com\n");
+
+        workspaceService.cleanupWorkspace(workspace);
+
+        assertThat(credentials).doesNotExist();
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -28,7 +28,7 @@ class WorkspaceServiceTest {
     }
     @Test
     void cleanupWorkspace_nullPath_doesNotThrow() {
-        workspaceService.cleanupWorkspace(null);
+        workspaceService.cleanupWorkspace((Path) null);
         // no exception expected
     }
 
@@ -70,6 +70,78 @@ class WorkspaceServiceTest {
         assertThat(content).isEqualTo("pr content");
 
         workspaceService.cleanupWorkspace(result.workspacePath());
+    }
+
+    @Test
+    void prepareWorkspace_fallbackRetainsExactlyOneWorkspaceDirectory() throws Exception {
+        // Regression for the agentic review BLOCKER: when the branch clone fails
+        // and the PR-ref fallback kicks in, the first workspace attempt must be
+        // fully removed before the second is created — otherwise a partial
+        // deletion could orphan the first attempt's credential-store file.
+        Path workspaceBaseDir = tempDir.resolve("sandbox-workspaces");
+        workspaceService = new WorkspaceService(workspaceBaseDir.toString());
+
+        Path remoteDir = tempDir.resolve("remote");
+        Files.createDirectories(remoteDir);
+        runGit(remoteDir, "init", "--bare");
+
+        Path localRepo = tempDir.resolve("local");
+        Files.createDirectories(localRepo);
+        runGit(localRepo, "init");
+        runGit(localRepo, "config", "user.email", "test@test.com");
+        runGit(localRepo, "config", "user.name", "Test");
+        runGit(localRepo, "branch", "-M", "main");
+        runGit(localRepo, "remote", "add", "origin", remoteDir.toAbsolutePath().toString());
+        Files.writeString(localRepo.resolve("README.md"), "pr content");
+        runGit(localRepo, "add", "README.md");
+        runGit(localRepo, "commit", "-m", "pr commit");
+        runGit(localRepo, "push", "-u", "origin", "main");
+        runGit(localRepo, "push", "origin", "main:refs/pull/42/head");
+
+        WorkspaceResult result = workspaceService.prepareWorkspace(
+                "any", "any", "nonexistent-branch",
+                remoteDir.toAbsolutePath().toString(), "dummy-token", 42L);
+
+        assertThat(result.success()).isTrue();
+
+        try (var children = Files.list(workspaceBaseDir)) {
+            assertThat(children
+                    .filter(path -> path.getFileName().toString().startsWith("agent-workspace-"))
+                    .count())
+                    .isEqualTo(1);
+        }
+
+        workspaceService.cleanupWorkspace(result.workspacePath());
+
+        try (var children = Files.list(workspaceBaseDir)) {
+            assertThat(children
+                    .filter(path -> path.getFileName().toString().startsWith("agent-workspace-"))
+                    .count())
+                    .isZero();
+        }
+    }
+
+    @Test
+    void cleanupWorkspace_setupDeletesCredentialFileAndRootTogether() throws IOException {
+        // The holder keeps the credential-file reference even when the file was
+        // never registered in the credentialsByWorkspace map — exactly the
+        // situation of the first attempt in the branch-clone fallback. Cleanup
+        // must remove the file and the private parent together.
+        WorkspaceSetup setup = workspaceService.createWorkspaceSetup();
+        Path credentials = workspaceService.createCredentialsFile(
+                "https://git.example.com", "test-token", setup.workspaceDir());
+        assertThat(credentials).isNotNull();
+
+        workspaceService.cleanupWorkspace(setup);
+
+        assertThat(credentials).doesNotExist();
+        assertThat(setup.workspaceRoot()).doesNotExist();
+    }
+
+    @Test
+    void cleanupWorkspace_setupNull_doesNotThrow() {
+        workspaceService.cleanupWorkspace((WorkspaceSetup) null);
+        // no exception expected
     }
     @Test
     void buildCloneUrl_http() {

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -1,10 +1,13 @@
 package org.remus.giteabot.agent.validation;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class WorkspaceServiceTest {
@@ -159,6 +162,52 @@ class WorkspaceServiceTest {
         Files.createDirectories(tempDir.resolve("empty-dir"));
 
         assertThat(workspaceService.hasUncommittedChanges(tempDir)).isFalse();
+    }
+
+    @Test
+    void commitAndPush_disablesWorkspaceHooks() throws Exception {
+        initGitRepository(tempDir);
+        Path remote = tempDir.resolve("remote");
+        Files.createDirectories(remote);
+        runGit(remote, "init", "--bare");
+        String branch = runGitCapture(tempDir, "branch", "--show-current");
+        runGit(tempDir, "remote", "add", "origin", remote.toAbsolutePath().toString());
+        runGit(tempDir, "push", "-u", "origin", branch);
+
+        Path hook = tempDir.resolve(".git/hooks/pre-commit");
+        Files.writeString(hook, "#!/bin/sh\nexit 1\n");
+        Assumptions.assumeTrue(Files.getFileStore(hook).supportsFileAttributeView("posix"));
+        Files.setPosixFilePermissions(hook, Set.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE));
+        Files.writeString(tempDir.resolve("README.md"), "changed");
+
+        assertThat(workspaceService.commitAndPush(tempDir, branch, "test commit",
+                "Test User", "test@example.com", false)).isTrue();
+    }
+
+    @Test
+    void gitCommands_disableWorkspaceFsMonitor() throws Exception {
+        initGitRepository(tempDir);
+        Path monitorDirectory = tempDir.getParent().resolve(tempDir.getFileName() + "-fsmonitor");
+        Files.createDirectories(monitorDirectory);
+        Path marker = monitorDirectory.resolve("ran");
+        Path monitor = monitorDirectory.resolve("monitor.sh");
+        Files.writeString(monitor, "#!/bin/sh\ntouch " + marker + "\n");
+        Assumptions.assumeTrue(Files.getFileStore(monitor).supportsFileAttributeView("posix"));
+        Files.setPosixFilePermissions(monitor, Set.of(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE));
+        runGit(tempDir, "config", "core.fsmonitor", monitor.toString());
+
+        runGit(tempDir, "status", "--porcelain");
+        assertThat(marker).exists();
+        Files.delete(marker);
+
+        assertThat(workspaceService.hasUncommittedChanges(tempDir)).isFalse();
+        assertThat(marker).doesNotExist();
     }
 
     private void initGitRepository(Path dir) throws IOException, InterruptedException {

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -112,6 +112,23 @@ class WorkspaceServiceTest {
     }
 
     @Test
+    void credentialConfigForWorkspace_usesExternalCredentialStore() throws IOException {
+        Path workspace = workspaceService.createWorkspaceDirectory();
+        Path credentials = workspaceService.createCredentialsFile(
+                "https://git.example.com", "test-token", workspace);
+
+        try {
+            workspaceService.registerCredentialsFile(workspace, credentials);
+
+            assertThat(workspaceService.credentialConfigForWorkspace(workspace)).containsExactly(
+                    "-c", "credential.helper=",
+                    "-c", "credential.helper=store --file=" + credentials.toAbsolutePath());
+        } finally {
+            workspaceService.cleanupWorkspace(workspace);
+        }
+    }
+
+    @Test
     void hasUncommittedChanges_detectsModifiedTrackedFile() throws IOException, InterruptedException {
         initGitRepository(tempDir);
         Path file = tempDir.resolve("README.md");

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class WorkspaceServiceTest {
     private WorkspaceService workspaceService;
     @TempDir
@@ -82,19 +83,32 @@ class WorkspaceServiceTest {
 
     @Test
     void createCredentialsFile_keepsTokenOutsideWorkspaceAndCleanupRemovesIt() throws IOException {
-        Path workspace = tempDir.resolve("workspace");
-        Files.createDirectories(workspace);
+        Path workspace = workspaceService.createWorkspaceDirectory();
 
         Path credentials = workspaceService.createCredentialsFile(
                 "https://git.example.com", "test-token", workspace);
 
-        assertThat(credentials).isEqualTo(tempDir.resolve("workspace.credentials"));
+        assertThat(credentials.getParent()).isEqualTo(workspace.getParent());
+        assertThat(credentials.getFileName().toString()).startsWith("credentials-");
         assertThat(credentials).isNotEqualTo(workspace.resolve(".git-credentials"));
+        assertThat(credentials).isNotEqualTo(workspace.resolveSibling("repository.credentials"));
         assertThat(Files.readString(credentials)).isEqualTo("https://oauth2:test-token@git.example.com\n");
 
         workspaceService.cleanupWorkspace(workspace);
 
         assertThat(credentials).doesNotExist();
+        assertThat(workspace.getParent()).doesNotExist();
+    }
+
+    @Test
+    void createCredentialsFile_rejectsWorkspaceWithoutPrivateParent() throws IOException {
+        Path unmanagedWorkspace = tempDir.resolve("workspace");
+        Files.createDirectories(unmanagedWorkspace);
+
+        assertThatThrownBy(() -> workspaceService.createCredentialsFile(
+                "https://git.example.com", "test-token", unmanagedWorkspace))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("private credential directory");
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
+++ b/src/test/java/org/remus/giteabot/agent/validation/WorkspaceServiceTest.java
@@ -101,6 +101,22 @@ class WorkspaceServiceTest {
     }
 
     @Test
+    void createWorkspaceDirectory_usesConfiguredBaseDirectory() throws IOException {
+        Path workspaceBaseDir = tempDir.resolve("sandbox-workspaces");
+        workspaceService = new WorkspaceService(workspaceBaseDir.toString());
+
+        Path workspace = workspaceService.createWorkspaceDirectory();
+
+        assertThat(workspace.startsWith(workspaceBaseDir.toAbsolutePath().normalize())).isTrue();
+        assertThat(workspace.getParent().getParent()).isEqualTo(workspaceBaseDir.toAbsolutePath().normalize());
+
+        workspaceService.cleanupWorkspace(workspace);
+
+        assertThat(workspace).doesNotExist();
+        assertThat(workspaceBaseDir).exists();
+    }
+
+    @Test
     void createCredentialsFile_rejectsWorkspaceWithoutPrivateParent() throws IOException {
         Path unmanagedWorkspace = tempDir.resolve("workspace");
         Files.createDirectories(unmanagedWorkspace);

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
@@ -62,6 +62,22 @@ class PrTestWorkspaceManagerTest {
     }
 
     @Test
+    void resolveInsideWorkspaceRejectsGitMetadataAndIntermediateSymlinks(@TempDir Path tmp) throws IOException {
+        PrTestWorkspaceManager manager = PrTestWorkspaceManager.rootedAt(tmp);
+        Path workspace = manager.allocate(1L, E2eTestFramework.PLAYWRIGHT);
+        Path outside = tmp.resolve("outside");
+        Files.createDirectories(outside);
+        Files.createSymbolicLink(workspace.resolve("linked"), outside);
+
+        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, ".git/config"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(".git internals");
+        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, "linked/secret.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symlinked directory");
+    }
+
+    @Test
     void cleanupRemovesEverythingUnderRunDir(@TempDir Path tmp) throws IOException {
         PrTestWorkspaceManager manager = PrTestWorkspaceManager.rootedAt(tmp);
         Path ws = manager.allocate(99L, E2eTestFramework.PLAYWRIGHT);
@@ -96,5 +112,4 @@ class PrTestWorkspaceManagerTest {
         assertThat(k6.resolve("scenarios")).isDirectory();
     }
 }
-
 

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
@@ -62,22 +62,6 @@ class PrTestWorkspaceManagerTest {
     }
 
     @Test
-    void resolveInsideWorkspaceRejectsGitMetadataAndIntermediateSymlinks(@TempDir Path tmp) throws IOException {
-        PrTestWorkspaceManager manager = PrTestWorkspaceManager.rootedAt(tmp);
-        Path workspace = manager.allocate(1L, E2eTestFramework.PLAYWRIGHT);
-        Path outside = tmp.resolve("outside");
-        Files.createDirectories(outside);
-        Files.createSymbolicLink(workspace.resolve("linked"), outside);
-
-        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, ".git/config"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(".git internals");
-        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, "linked/secret.txt"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("symlinked directory");
-    }
-
-    @Test
     void cleanupRemovesEverythingUnderRunDir(@TempDir Path tmp) throws IOException {
         PrTestWorkspaceManager manager = PrTestWorkspaceManager.rootedAt(tmp);
         Path ws = manager.allocate(99L, E2eTestFramework.PLAYWRIGHT);
@@ -112,4 +96,3 @@ class PrTestWorkspaceManagerTest {
         assertThat(k6.resolve("scenarios")).isDirectory();
     }
 }
-

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerWorkspacePathsTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerWorkspacePathsTest.java
@@ -1,0 +1,30 @@
+package org.remus.giteabot.prworkflow.e2e.workspace;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.remus.giteabot.prworkflow.e2e.E2eTestFramework;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PrTestWorkspaceManagerWorkspacePathsTest {
+
+    @Test
+    void resolveInsideWorkspaceRejectsGitMetadataAndIntermediateSymlinks(@TempDir Path tmp) throws IOException {
+        PrTestWorkspaceManager manager = PrTestWorkspaceManager.rootedAt(tmp);
+        Path workspace = manager.allocate(1L, E2eTestFramework.PLAYWRIGHT);
+        Path outside = tmp.resolve("outside");
+        Files.createDirectories(outside);
+        Files.createSymbolicLink(workspace.resolve("linked"), outside);
+
+        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, ".git/config"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(".git internals");
+        assertThatThrownBy(() -> manager.resolveInsideWorkspace(workspace, "linked/secret.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symlinked directory");
+    }
+}

--- a/src/test/java/org/remus/giteabot/util/WorkspacePathsTest.java
+++ b/src/test/java/org/remus/giteabot/util/WorkspacePathsTest.java
@@ -1,0 +1,50 @@
+package org.remus.giteabot.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WorkspacePathsTest {
+
+    @Test
+    void resolveInsideWorkspace_allowsNewFilesWithinWorkspace(@TempDir Path root) throws IOException {
+        Path workspace = root.resolve("workspace");
+        Files.createDirectories(workspace);
+
+        Path result = WorkspacePaths.resolveInsideWorkspace(workspace, "src/Main.java");
+
+        assertThat(result).isEqualTo(workspace.resolve("src/Main.java"));
+    }
+
+    @Test
+    void resolveInsideWorkspace_rejectsTraversalAndGitMetadata(@TempDir Path root) throws IOException {
+        Path workspace = root.resolve("workspace");
+        Files.createDirectories(workspace.resolve(".git"));
+
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, "../outside.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("escapes the workspace");
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, ".git/config"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(".git internals");
+    }
+
+    @Test
+    void resolveInsideWorkspace_rejectsIntermediateSymlink(@TempDir Path root) throws IOException {
+        Path workspace = root.resolve("workspace");
+        Path outside = root.resolve("outside");
+        Files.createDirectories(workspace);
+        Files.createDirectories(outside);
+        Files.createSymbolicLink(workspace.resolve("linked"), outside);
+
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, "linked/secret.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("symlinked directory");
+    }
+}

--- a/src/test/java/org/remus/giteabot/util/WorkspacePathsTest.java
+++ b/src/test/java/org/remus/giteabot/util/WorkspacePathsTest.java
@@ -33,6 +33,23 @@ class WorkspacePathsTest {
         assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, ".git/config"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining(".git internals");
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, ".GIT/config"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(".git internals");
+    }
+
+    @Test
+    void resolveInsideWorkspace_rejectsAbsoluteAndNormalizedTraversalPaths(@TempDir Path root) throws IOException {
+        Path workspace = root.resolve("workspace");
+        Files.createDirectories(workspace);
+
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(
+                workspace, workspace.resolve("inside.txt").toString()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("relative");
+        assertThatThrownBy(() -> WorkspacePaths.resolveInsideWorkspace(workspace, "src/../inside.txt"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("traversal");
     }
 
     @Test


### PR DESCRIPTION
## What was done and why?

- Centralizes workspace path validation and rejects absolute paths, traversal, Git metadata, and symlink escapes.
- Prevents repository tools from recursively reading Git metadata or files reached through symlinks.
- Keeps Git credentials outside cloned repositories in a private temporary parent with owner-only permissions and cleanup.
- Runs trusted host-side Git operations with empty hooks, scrubbed environments, and isolated global configuration.
- Supports an optional host-visible root while retaining private workspace parents for Docker sandbox mounts.
- Adds regressions for case-insensitive Git metadata, path normalization, symlinks, credential placement, cleanup, configured workspace roots, hooks, and fsmonitor.

## Testing

- Build and verify CI
- Focused workspace-boundary regression tests
- Git whitespace validation

### AI use

- Initial implementation used KIMI K3; the split, hardening, and review used OpenCode (gpt-5.6-terra).