### PR TITLE
Harden untrusted command execution

### DIFF
--- a/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
@@ -4,12 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.agent.tools.ToolCatalog;
 import org.remus.giteabot.config.AgentConfigProperties;
+import org.remus.giteabot.util.ProcessSupport;
 import org.springframework.stereotype.Service;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -1283,34 +1282,26 @@ public class ToolExecutionService {
             ProcessBuilder pb = new ProcessBuilder(command);
             pb.directory(workspaceDir.toFile());
             pb.redirectErrorStream(true);
-
-            Process process = pb.start();
-
-            StringBuilder output = new StringBuilder();
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream()))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    output.append(line).append("\n");
-                }
-            }
+            // Untrusted repository code (package-manager scripts, test fixtures) must
+            // never see application secrets such as database or AI provider keys.
+            ProcessSupport.scrubEnvironment(pb);
 
             int timeoutSeconds = agentConfig.getValidation().getToolTimeoutSeconds();
-            boolean finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS);
+            ProcessSupport.CommandResult result = ProcessSupport.run(pb, timeoutSeconds,
+                    TimeUnit.SECONDS, MAX_TOOL_OUTPUT_CHARS + 1_000);
 
-            if (!finished) {
-                process.destroyForcibly();
+            if (!result.finished()) {
                 return new ToolResult(false, -1, "",
                         "Tool execution timed out after " + timeoutSeconds + " seconds");
             }
 
-            int exitCode = process.exitValue();
+            int exitCode = result.exitCode();
             boolean success = exitCode == 0;
 
             log.info("Tool {} with exit code {}",
                     success ? "succeeded" : "failed", exitCode);
 
-            return new ToolResult(success, exitCode, truncateOutput(output.toString()), "");
+            return new ToolResult(success, exitCode, truncateOutput(result.output()), "");
 
         } catch (IOException e) {
             log.error("Failed to execute tool: {}", e.getMessage());

--- a/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/ToolExecutionService.java
@@ -1287,6 +1287,10 @@ public class ToolExecutionService {
             ProcessSupport.scrubEnvironment(pb);
 
             int timeoutSeconds = agentConfig.getValidation().getToolTimeoutSeconds();
+            // The byte cap is the hard memory bound while draining the pipe; the
+            // character cap below is the presentation limit. The +1_000 headroom
+            // makes the char cap the effective limit for ASCII-dominant output,
+            // while multi-byte-heavy output may hit the byte cap first.
             ProcessSupport.CommandResult result = ProcessSupport.run(pb, timeoutSeconds,
                     TimeUnit.SECONDS, MAX_TOOL_OUTPUT_CHARS + 1_000);
 

--- a/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
+++ b/src/main/java/org/remus/giteabot/agent/validation/WorkspaceService.java
@@ -1,6 +1,7 @@
 package org.remus.giteabot.agent.validation;
 
 import lombok.extern.slf4j.Slf4j;
+import org.remus.giteabot.util.ProcessSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -49,11 +49,6 @@ public class WorkspaceService {
     private static final Set<PosixFilePermission> OWNER_FILE_PERMISSIONS = Set.of(
             PosixFilePermission.OWNER_READ,
             PosixFilePermission.OWNER_WRITE);
-    private static final List<String> GIT_ENVIRONMENT_ALLOWLIST = List.of(
-            "PATH", "LANG", "LC_ALL", "LC_CTYPE", "TZ", "TMPDIR", "TMP", "TEMP",
-            "SystemRoot", "windir", "COMSPEC", "PATHEXT",
-            "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy",
-            "GIT_SSL_CAINFO", "GIT_SSL_CAPATH", "SSL_CERT_FILE", "SSL_CERT_DIR");
     private final Path workspaceBaseDir;
     private final ConcurrentMap<Path, Path> credentialsByWorkspace = new ConcurrentHashMap<>();
 
@@ -534,7 +529,7 @@ public class WorkspaceService {
             ProcessBuilder pb = new ProcessBuilder(gitCommand);
             pb.directory(workDir);
             pb.redirectErrorStream(true);
-            scrubEnvironmentForGit(pb);
+            ProcessSupport.scrubEnvironmentForGit(pb);
             pb.environment().put("GIT_CONFIG_NOSYSTEM", "1");
             pb.environment().put("GIT_CONFIG_GLOBAL", emptyGlobalGitConfig.toString());
 
@@ -579,18 +574,6 @@ public class WorkspaceService {
                     log.warn("Failed to remove empty Git hooks directory {}: {}",
                             disabledHooksDirectory, e.getMessage());
                 }
-            }
-        }
-    }
-
-    /** Keeps credentials and application secrets out of Git subprocesses. */
-    private void scrubEnvironmentForGit(ProcessBuilder processBuilder) {
-        Map<String, String> environment = processBuilder.environment();
-        environment.clear();
-        for (String name : GIT_ENVIRONMENT_ALLOWLIST) {
-            String value = System.getenv(name);
-            if (value != null) {
-                environment.put(name, value);
             }
         }
     }

--- a/src/main/java/org/remus/giteabot/prworkflow/e2e/tools/WorkspaceProcessRunner.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/e2e/tools/WorkspaceProcessRunner.java
@@ -1,5 +1,6 @@
 package org.remus.giteabot.prworkflow.e2e.tools;
 
+import org.remus.giteabot.util.ProcessSupport;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -18,6 +19,10 @@ import java.util.concurrent.TimeUnit;
  * stream because most test frameworks (Playwright, pytest, k6) interleave
  * them, and the agent only needs a single textual blob to reason about the
  * outcome.</p>
+ *
+ * <p>Commands execute with a scrubbed environment (no application secrets)
+ * and the strongest local lifetime control available, see
+ * {@link ProcessSupport}.</p>
  */
 @Component
 public class WorkspaceProcessRunner {
@@ -36,8 +41,8 @@ public class WorkspaceProcessRunner {
      * stdout/stderr (UTF-8) up to {@code maxOutputBytes} bytes and waiting
      * at most {@code timeout} ms before terminating the process.
      *
-     * @param extraEnv environment overrides applied on top of the inherited
-     *                 JVM environment (later entries win). Use this to inject
+     * @param extraEnv environment overrides applied on top of the scrubbed
+     *                 environment (later entries win). Use this to inject
      *                 {@code BASE_URL} for browser tests or
      *                 {@code PLAYWRIGHT_JSON_OUTPUT_NAME} to route the report.
      */
@@ -48,47 +53,19 @@ public class WorkspaceProcessRunner {
         ProcessBuilder pb = new ProcessBuilder(command)
                 .directory(workspace.toFile())
                 .redirectErrorStream(true);
+        ProcessSupport.scrubEnvironment(pb);
         // Make sure CI-style envs do not break the runner with interactive prompts.
-        pb.environment().putIfAbsent("CI", "1");
+        pb.environment().put("CI", "1");
         if (extraEnv != null) {
             for (Map.Entry<String, String> e : extraEnv.entrySet()) {
                 if (e.getKey() == null || e.getValue() == null) continue;
                 pb.environment().put(e.getKey(), e.getValue());
             }
         }
-        Process process = pb.start();
-        StringBuilder out = new StringBuilder();
-        Thread reader = new Thread(() -> {
-            try (var in = process.getInputStream()) {
-                byte[] buf = new byte[8192];
-                int read;
-                while ((read = in.read(buf)) > 0) {
-                    if (out.length() >= maxOutputBytes) {
-                        // Drain so the child does not block on a full pipe.
-                        continue;
-                    }
-                    int spare = Math.max(0, maxOutputBytes - out.length());
-                    int take = Math.min(read, spare);
-                    if (take > 0) {
-                        out.append(new String(buf, 0, take, java.nio.charset.StandardCharsets.UTF_8));
-                    }
-                }
-            } catch (IOException ignored) {
-                // process exited
-            }
-        }, "pr-test-run-reader");
-        reader.setDaemon(true);
-        reader.start();
-
-        boolean finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS);
-        if (!finished) {
-            process.destroyForcibly();
-            reader.join(2_000);
-            long durationMs = (System.nanoTime() - start) / 1_000_000L;
-            return new ProcessResult(-1, out.toString(), durationMs, true);
-        }
-        reader.join(2_000);
+        ProcessSupport.CommandResult result = ProcessSupport.run(pb, timeoutMs,
+                TimeUnit.MILLISECONDS, maxOutputBytes);
         long durationMs = (System.nanoTime() - start) / 1_000_000L;
-        return new ProcessResult(process.exitValue(), out.toString(), durationMs, false);
+        return new ProcessResult(result.finished() ? result.exitCode() : -1,
+                result.output(), durationMs, !result.finished());
     }
 }

--- a/src/main/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManager.java
+++ b/src/main/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManager.java
@@ -2,6 +2,7 @@ package org.remus.giteabot.prworkflow.e2e.workspace;
 
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.prworkflow.e2e.E2eTestFramework;
+import org.remus.giteabot.util.ProcessSupport;
 import org.remus.giteabot.util.WorkspacePaths;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,13 @@ public class PrTestWorkspaceManager {
     private final Path root;
     private final boolean npmInstallEnabled;
 
+    /**
+     * Creates the manager with the configured workspace root.
+     *
+     * @param configuredRoot absolute host-visible root for generated workspaces;
+     *                       a relative value is rejected to avoid silently resolving
+     *                       it against the process working directory
+     */
     public PrTestWorkspaceManager(
             @Value("${ai-git-bot.e2e.workspace-root:#{null}}") String configuredRoot,
             @Value("${ai-git-bot.e2e.npm-install-enabled:true}") boolean npmInstallEnabled) {
@@ -47,7 +55,13 @@ public class PrTestWorkspaceManager {
             this.root = Path.of(System.getProperty("java.io.tmpdir"), "ai-bot-pr-tests")
                     .toAbsolutePath().normalize();
         } else {
-            this.root = Path.of(configuredRoot).toAbsolutePath().normalize();
+            Path configured = Path.of(configuredRoot);
+            if (!configured.isAbsolute()) {
+                throw new IllegalArgumentException(
+                        "ai-git-bot.e2e.workspace-root must be an absolute path, but was: "
+                                + configuredRoot);
+            }
+            this.root = configured.normalize();
         }
         this.npmInstallEnabled = npmInstallEnabled;
         log.debug("PrTestWorkspaceManager root={} npmInstallEnabled={}", root, npmInstallEnabled);
@@ -269,22 +283,17 @@ public class PrTestWorkspaceManager {
             ProcessBuilder pb = new ProcessBuilder(cmd)
                     .directory(workspace.toFile())
                     .redirectErrorStream(true);
-            pb.environment().putIfAbsent("CI", "1");
-            Process p = pb.start();
-            try (var in = p.getInputStream()) {
-                // Drain so the child does not block on a full pipe — but we
-                // do not need to keep the output beyond the log line below.
-                in.readAllBytes();
-            }
-            boolean finished = p.waitFor(120, TimeUnit.SECONDS);
-            if (!finished) {
-                p.destroyForcibly();
+            ProcessSupport.scrubEnvironment(pb);
+            pb.environment().put("CI", "1");
+            ProcessSupport.CommandResult result = ProcessSupport.run(pb, 120,
+                    TimeUnit.SECONDS, 64 * 1024);
+            if (!result.finished()) {
                 log.warn("npm install of {} in {} timed out after 120s", packageSpec, workspace);
                 return;
             }
-            if (p.exitValue() != 0) {
+            if (result.exitCode() != 0) {
                 log.warn("npm install of {} in {} exited with code {}",
-                        packageSpec, workspace, p.exitValue());
+                        packageSpec, workspace, result.exitCode());
             } else {
                 log.debug("npm install of {} in {} succeeded", packageSpec, workspace);
             }

--- a/src/main/java/org/remus/giteabot/util/ProcessSupport.java
+++ b/src/main/java/org/remus/giteabot/util/ProcessSupport.java
@@ -93,6 +93,21 @@ public final class ProcessSupport {
     /**
      * Starts an untrusted process in a dedicated Linux process group so normal
      * background children cannot survive after the command completes.
+     * <p>
+     * The process-group leader is the PID returned by
+     * {@link ProcessBuilder#start()}: util-linux {@code setsid} forks only when
+     * it is already a process-group leader ({@code getpgrp() == getpid()}). A
+     * {@code ProcessBuilder} child inherits the JVM's process group, and the
+     * kernel never allocates a PID that is still in use, so as long as the
+     * JVM's group leader lives, the child can never be a leader itself;
+     * {@code setsid} then calls {@code setsid(2)} and {@code execvp}s the
+     * target in the same process, preserving the PID as the new PGID.
+     * <p>
+     * Known limitation: a child that daemonizes itself (calls {@code setsid}
+     * again) leaves the process group and survives cleanup; on non-Linux
+     * platforms a reparented daemon escapes the best-effort descendant tracker
+     * the same way. Closing that gap requires uid/cgroup separation, which is
+     * the follow-up hard-isolation layer.
      */
     public static CommandResult runInNewProcessGroup(ProcessBuilder processBuilder, long timeout, TimeUnit unit,
                                                        int maxOutputBytes) throws IOException, InterruptedException {
@@ -169,6 +184,9 @@ public final class ProcessSupport {
     }
 
     private static void terminateProcessGroup(long leaderPid) {
+        // The leader PID is the process-group ID: setsid(2) made the process a
+        // session and group leader, and execvp preserved the PID (see
+        // runInNewProcessGroup). The group ID stays valid while any member lives.
         try {
             ProcessBuilder processBuilder = new ProcessBuilder("kill", "-KILL", "--", "-" + leaderPid);
             processBuilder.redirectErrorStream(true);
@@ -245,11 +263,16 @@ public final class ProcessSupport {
     }
 
     private static Thread startDescendantTracker(Process process, Set<ProcessHandle> trackedDescendants) {
+        // Polling interval is a trade-off, not a correctness parameter: a child
+        // that spawns and dies between two ticks needs no kill, and a child that
+        // is alive at any tick is captured. A shorter interval only catches
+        // short-lived intermediate links of a fork chain before their children
+        // get orphaned; 250ms keeps the per-command overhead negligible.
         Thread tracker = new Thread(() -> {
             while (process.isAlive() && !Thread.currentThread().isInterrupted()) {
                 captureDescendants(process, trackedDescendants);
                 try {
-                    Thread.sleep(10);
+                    Thread.sleep(250);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }

--- a/src/main/java/org/remus/giteabot/util/ProcessSupport.java
+++ b/src/main/java/org/remus/giteabot/util/ProcessSupport.java
@@ -1,0 +1,293 @@
+package org.remus.giteabot.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/** Helpers for spawning untrusted tool processes without application secrets. */
+public final class ProcessSupport {
+
+    private static final int OUTPUT_BUFFER_SIZE = 8192;
+
+    private static final List<String> CHILD_ENV_ALLOWLIST = List.of(
+            "PATH", "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TZ",
+            "TMPDIR", "TMP", "TEMP",
+            "JAVA_HOME", "GOPATH", "GOROOT", "CARGO_HOME", "RUSTUP_HOME",
+            "NODE_PATH", "NPM_CONFIG_PREFIX",
+            "PIP_BREAK_SYSTEM_PACKAGES",
+            "PLAYWRIGHT_BROWSERS_PATH", "CYPRESS_CACHE_FOLDER", "DOTNET_ROOT",
+            "SystemRoot", "windir", "COMSPEC", "PATHEXT", "APPDATA", "LOCALAPPDATA",
+            "USERPROFILE", "HOMEDRIVE", "HOMEPATH", "PUBLIC", "ProgramData", "PSModulePath");
+
+    private static final List<String> GIT_TRANSPORT_ENV_ALLOWLIST = List.of(
+            "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy",
+            "GIT_SSL_CAINFO", "GIT_SSL_CAPATH", "SSL_CERT_FILE", "SSL_CERT_DIR");
+
+    private ProcessSupport() {
+    }
+
+    /** Captured result of a process whose combined output was drained asynchronously. */
+    public record CommandResult(boolean finished, int exitCode, String output) {
+    }
+
+    /** Replaces a child process environment with the minimal toolchain allowlist. */
+    public static void scrubEnvironment(ProcessBuilder processBuilder) {
+        Map<String, String> environment = processBuilder.environment();
+        environment.clear();
+        for (String name : CHILD_ENV_ALLOWLIST) {
+            String value = System.getenv(name);
+            if (value != null) {
+                environment.put(name, value);
+            }
+        }
+    }
+
+    /** Applies a minimal environment for Git transport without inheriting user Git configuration. */
+    public static void scrubEnvironmentForGit(ProcessBuilder processBuilder) {
+        scrubEnvironment(processBuilder);
+        Map<String, String> environment = processBuilder.environment();
+        environment.remove("HOME");
+        environment.remove("USERPROFILE");
+        environment.remove("HOMEDRIVE");
+        environment.remove("HOMEPATH");
+        environment.remove("APPDATA");
+        environment.remove("LOCALAPPDATA");
+        for (String name : GIT_TRANSPORT_ENV_ALLOWLIST) {
+            String value = System.getenv(name);
+            if (value != null) {
+                environment.put(name, value);
+            }
+        }
+    }
+
+    /**
+     * Waits for a process while draining its output concurrently, so an open
+     * output pipe cannot prevent the timeout from taking effect.
+     */
+    public static CommandResult waitFor(Process process, long timeout, TimeUnit unit, int maxOutputBytes)
+            throws InterruptedException {
+        return waitFor(process, timeout, unit, maxOutputBytes, () -> { }, true);
+    }
+
+    /**
+     * Runs an untrusted command with the strongest local isolation available:
+     * a dedicated process group on Linux (so background children cannot
+     * survive), plain execution with descendant tracking elsewhere.
+     */
+    public static CommandResult run(ProcessBuilder processBuilder, long timeout, TimeUnit unit,
+                                    int maxOutputBytes) throws IOException, InterruptedException {
+        if (isLinux()) {
+            return runInNewProcessGroup(processBuilder, timeout, unit, maxOutputBytes);
+        }
+        return waitFor(processBuilder.start(), timeout, unit, maxOutputBytes);
+    }
+
+    /**
+     * Starts an untrusted process in a dedicated Linux process group so normal
+     * background children cannot survive after the command completes.
+     */
+    public static CommandResult runInNewProcessGroup(ProcessBuilder processBuilder, long timeout, TimeUnit unit,
+                                                       int maxOutputBytes) throws IOException, InterruptedException {
+        if (!isLinux()) {
+            throw new IOException("Process-group isolation requires Linux");
+        }
+
+        List<String> originalCommand = List.copyOf(processBuilder.command());
+        List<String> groupedCommand = new ArrayList<>(originalCommand.size() + 1);
+        groupedCommand.add("setsid");
+        groupedCommand.addAll(originalCommand);
+        processBuilder.command(groupedCommand);
+        try {
+            Process process = processBuilder.start();
+            return waitFor(process, timeout, unit, maxOutputBytes,
+                    () -> terminateProcessGroup(process.pid()), false);
+        } catch (IOException e) {
+            processBuilder.command(originalCommand);
+            throw new IOException("Process-group isolation requires the setsid utility", e);
+        }
+    }
+
+    private static CommandResult waitFor(Process process, long timeout, TimeUnit unit, int maxOutputBytes,
+                                         Runnable processGroupCleanup, boolean trackDescendants)
+            throws InterruptedException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Set<ProcessHandle> descendants = ConcurrentHashMap.newKeySet();
+        Thread descendantTracker = null;
+        if (trackDescendants) {
+            captureDescendants(process, descendants);
+            descendantTracker = startDescendantTracker(process, descendants);
+        }
+        Thread reader = startOutputReader(process, output, Math.max(0, maxOutputBytes));
+        try {
+            boolean finished = process.waitFor(timeout, unit);
+            if (finished) {
+                // A successful command must not leave build daemons running outside its lifetime.
+                processGroupCleanup.run();
+                captureDescendants(process, descendants);
+                terminateDescendants(descendants);
+                terminateDescendantsForcibly(descendants);
+            } else {
+                processGroupCleanup.run();
+                terminateProcessTree(process, descendants);
+                closeOutput(process);
+                process.waitFor(5, TimeUnit.SECONDS);
+            }
+            reader.join(2_000);
+            if (reader.isAlive()) {
+                // A background descendant kept the inherited output pipe open.
+                processGroupCleanup.run();
+                terminateProcessTree(process, descendants);
+                closeOutput(process);
+                reader.join(2_000);
+            }
+            synchronized (output) {
+                return new CommandResult(finished, finished ? process.exitValue() : -1,
+                        decodeUtf8(output.toByteArray()));
+            }
+        } catch (InterruptedException e) {
+            processGroupCleanup.run();
+            terminateProcessTree(process, descendants);
+            closeOutput(process);
+            throw e;
+        } finally {
+            if (descendantTracker != null) {
+                descendantTracker.interrupt();
+            }
+        }
+    }
+
+    private static boolean isLinux() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("linux");
+    }
+
+    private static void terminateProcessGroup(long leaderPid) {
+        try {
+            ProcessBuilder processBuilder = new ProcessBuilder("kill", "-KILL", "--", "-" + leaderPid);
+            processBuilder.redirectErrorStream(true);
+            scrubEnvironment(processBuilder);
+            waitFor(processBuilder.start(), 5, TimeUnit.SECONDS, 64 * 1024);
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static String decodeUtf8(byte[] output) {
+        int length = output.length;
+        while (length > 0) {
+            int sequenceStart = length - 1;
+            while (sequenceStart >= 0 && isUtf8ContinuationByte(output[sequenceStart])) {
+                sequenceStart--;
+            }
+            if (sequenceStart < 0) {
+                return "";
+            }
+            int sequenceLength = utf8SequenceLength(output[sequenceStart]);
+            if (sequenceLength == 0) {
+                length = sequenceStart;
+            } else if (length - sequenceStart >= sequenceLength) {
+                return new String(output, 0, length, StandardCharsets.UTF_8);
+            } else {
+                length = sequenceStart;
+            }
+        }
+        return "";
+    }
+
+    private static boolean isUtf8ContinuationByte(byte value) {
+        return (value & 0xC0) == 0x80;
+    }
+
+    private static int utf8SequenceLength(byte value) {
+        int unsignedValue = Byte.toUnsignedInt(value);
+        if (unsignedValue <= 0x7F) {
+            return 1;
+        }
+        if (unsignedValue >= 0xC2 && unsignedValue <= 0xDF) {
+            return 2;
+        }
+        if (unsignedValue >= 0xE0 && unsignedValue <= 0xEF) {
+            return 3;
+        }
+        if (unsignedValue >= 0xF0 && unsignedValue <= 0xF4) {
+            return 4;
+        }
+        return 0;
+    }
+
+    private static void terminateProcessTree(Process process, Set<ProcessHandle> trackedDescendants) {
+        captureDescendants(process, trackedDescendants);
+        terminateDescendants(trackedDescendants);
+        process.destroy();
+        terminateDescendantsForcibly(trackedDescendants);
+        process.destroyForcibly();
+    }
+
+    private static void captureDescendants(Process process, Set<ProcessHandle> trackedDescendants) {
+        trackedDescendants.addAll(process.toHandle().descendants().toList());
+    }
+
+    private static void terminateDescendants(Set<ProcessHandle> descendants) {
+        descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroy);
+    }
+
+    private static void terminateDescendantsForcibly(Set<ProcessHandle> descendants) {
+        descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
+    }
+
+    private static Thread startDescendantTracker(Process process, Set<ProcessHandle> trackedDescendants) {
+        Thread tracker = new Thread(() -> {
+            while (process.isAlive() && !Thread.currentThread().isInterrupted()) {
+                captureDescendants(process, trackedDescendants);
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            captureDescendants(process, trackedDescendants);
+        }, "process-descendant-tracker");
+        tracker.setDaemon(true);
+        tracker.start();
+        return tracker;
+    }
+
+    private static void closeOutput(Process process) {
+        try {
+            process.getInputStream().close();
+        } catch (IOException ignored) {
+            // The process already closed its output stream.
+        }
+    }
+
+    private static Thread startOutputReader(Process process, ByteArrayOutputStream output, int maxOutputBytes) {
+        Thread reader = new Thread(() -> {
+            byte[] buffer = new byte[OUTPUT_BUFFER_SIZE];
+            try (InputStream input = process.getInputStream()) {
+                int read;
+                while ((read = input.read(buffer)) != -1) {
+                    synchronized (output) {
+                        int remaining = maxOutputBytes - output.size();
+                        if (remaining > 0) {
+                            output.write(buffer, 0, Math.min(read, remaining));
+                        }
+                    }
+                }
+            } catch (IOException ignored) {
+                // The process exited while its stream was being drained.
+            }
+        }, "process-output-reader");
+        reader.setDaemon(true);
+        reader.start();
+        return reader;
+    }
+}

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/tools/WorkspaceProcessRunnerTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/tools/WorkspaceProcessRunnerTest.java
@@ -1,0 +1,98 @@
+package org.remus.giteabot.prworkflow.e2e.tools;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WorkspaceProcessRunnerTest {
+
+    private final WorkspaceProcessRunner runner = new WorkspaceProcessRunner();
+
+    @Test
+    void run_capturesOutputAndExitCode(@TempDir Path workspace) throws Exception {
+        WorkspaceProcessRunner.ProcessResult result = runner.run(workspace,
+                javaCommand(EchoProcess.class.getName(), "hello world"), 10_000, 1024);
+
+        assertThat(result.exitCode()).isEqualTo(0);
+        assertThat(result.combinedOutput()).isEqualTo("hello world");
+        assertThat(result.timedOut()).isFalse();
+        assertThat(result.durationMs()).isGreaterThanOrEqualTo(0);
+    }
+
+    @Test
+    void run_appliesExtraEnvironment(@TempDir Path workspace) throws Exception {
+        WorkspaceProcessRunner.ProcessResult result = runner.run(workspace,
+                javaCommand(EnvDumpProcess.class.getName(), "MY_MARKER"),
+                Map.of("MY_MARKER", "injected-value"), 10_000, 1024);
+
+        assertThat(result.combinedOutput()).isEqualTo("injected-value");
+    }
+
+    @Test
+    void run_inheritsAllowlistedToolchainEnvironment(@TempDir Path workspace) throws Exception {
+        // PATH is part of the scrubbed-toolchain allowlist and must survive
+        // so the child can resolve executables. Secret scrubbing itself is
+        // covered by ProcessSupportTest.
+        WorkspaceProcessRunner.ProcessResult result = runner.run(workspace,
+                javaCommand(EnvDumpProcess.class.getName(), "PATH"), 10_000, 4096);
+
+        assertThat(result.combinedOutput()).isNotBlank();
+    }
+
+    @Test
+    void run_timesOutLongRunningCommands(@TempDir Path workspace) throws Exception {
+        WorkspaceProcessRunner.ProcessResult result = runner.run(workspace,
+                javaCommand(SleepyProcess.class.getName()), 500, 1024);
+
+        assertThat(result.timedOut()).isTrue();
+        assertThat(result.exitCode()).isEqualTo(-1);
+    }
+
+    @Test
+    void run_boundsCombinedOutput(@TempDir Path workspace) throws Exception {
+        WorkspaceProcessRunner.ProcessResult result = runner.run(workspace,
+                javaCommand(VerboseProcess.class.getName()), 10_000, 64);
+
+        assertThat(result.combinedOutput().getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
+                .isLessThanOrEqualTo(64);
+    }
+
+    private static List<String> javaCommand(String className, String... args) {
+        String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        java.util.List<String> command = new java.util.ArrayList<>(List.of(
+                Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                "-cp", System.getProperty("java.class.path"), className));
+        command.addAll(List.of(args));
+        return command;
+    }
+
+    public static final class EchoProcess {
+        public static void main(String[] args) {
+            System.out.print(String.join(" ", args));
+        }
+    }
+
+    public static final class EnvDumpProcess {
+        public static void main(String[] args) {
+            String value = System.getenv(args[0]);
+            System.out.print(value != null ? value : "");
+        }
+    }
+
+    public static final class SleepyProcess {
+        public static void main(String[] args) throws InterruptedException {
+            Thread.sleep(30_000);
+        }
+    }
+
+    public static final class VerboseProcess {
+        public static void main(String[] args) {
+            System.out.print("x".repeat(4096));
+        }
+    }
+}

--- a/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
+++ b/src/test/java/org/remus/giteabot/prworkflow/e2e/workspace/PrTestWorkspaceManagerTest.java
@@ -95,4 +95,13 @@ class PrTestWorkspaceManagerTest {
         Path k6 = manager.allocate(4L, E2eTestFramework.K6);
         assertThat(k6.resolve("scenarios")).isDirectory();
     }
+
+    @Test
+    void rejectsRelativeConfiguredRoot() {
+        // A relative root would silently resolve against the process working
+        // directory; the manager must fail fast instead.
+        assertThatThrownBy(() -> new PrTestWorkspaceManager("relative/root", false))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("absolute");
+    }
 }

--- a/src/test/java/org/remus/giteabot/util/ProcessSupportTest.java
+++ b/src/test/java/org/remus/giteabot/util/ProcessSupportTest.java
@@ -61,6 +61,26 @@ class ProcessSupportTest {
     }
 
     @Test
+    void runInNewProcessGroup_terminatesBackgroundChildOnTimeout(
+            @org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+        String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        Path heartbeat = tempDir.resolve("heartbeat");
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                "-cp", System.getProperty("java.class.path"),
+                BackgroundChildAndSleepProcess.class.getName(), heartbeat.toString())
+                .redirectErrorStream(true);
+
+        ProcessSupport.CommandResult result = ProcessSupport.runInNewProcessGroup(processBuilder,
+                5, TimeUnit.SECONDS, 1024);
+
+        assertThat(result.finished()).isFalse();
+        String heartbeatAtTimeout = Files.readString(heartbeat);
+        Thread.sleep(250);
+        assertThat(Files.readString(heartbeat)).isEqualTo(heartbeatAtTimeout);
+    }
+
+    @Test
     void waitFor_boundsOutputWithoutSplittingUtf8Characters() throws Exception {
         String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
         Process process = new ProcessBuilder(
@@ -111,6 +131,25 @@ class ProcessSupportTest {
             }
             System.out.print("started");
             System.out.flush();
+        }
+    }
+
+    public static final class BackgroundChildAndSleepProcess {
+        public static void main(String[] args) throws Exception {
+            String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+            new ProcessBuilder(
+                    Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                    "-cp", System.getProperty("java.class.path"), BackgroundHeartbeatChild.class.getName(),
+                    args[0])
+                    .inheritIO()
+                    .start();
+            Path heartbeat = Path.of(args[0]);
+            for (int attempt = 0; attempt < 100 && !Files.exists(heartbeat); attempt++) {
+                Thread.sleep(10);
+            }
+            System.out.print("started");
+            System.out.flush();
+            Thread.sleep(30_000);
         }
     }
 

--- a/src/test/java/org/remus/giteabot/util/ProcessSupportTest.java
+++ b/src/test/java/org/remus/giteabot/util/ProcessSupportTest.java
@@ -1,0 +1,132 @@
+package org.remus.giteabot.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProcessSupportTest {
+
+    @Test
+    void scrubEnvironment_removesUnexpectedVariables() {
+        ProcessBuilder processBuilder = new ProcessBuilder("unused-command");
+        processBuilder.environment().put("APP_ENCRYPTION_KEY", "should-not-be-inherited");
+        processBuilder.environment().put("UNRELATED_SECRET", "should-not-be-inherited");
+
+        ProcessSupport.scrubEnvironment(processBuilder);
+
+        assertThat(processBuilder.environment())
+                .doesNotContainKeys("APP_ENCRYPTION_KEY", "UNRELATED_SECRET");
+    }
+
+    @Test
+    void waitFor_enforcesTimeoutWhileOutputPipeRemainsOpen() throws Exception {
+        String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        Process process = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                "-cp", System.getProperty("java.class.path"),
+                SlowOutputProcess.class.getName())
+                .redirectErrorStream(true)
+                .start();
+
+        ProcessSupport.CommandResult result = ProcessSupport.waitFor(process, 2, TimeUnit.SECONDS, 1024);
+
+        assertThat(result.finished()).isFalse();
+        assertThat(result.output()).contains("started");
+    }
+
+    @Test
+    void waitFor_terminatesBackgroundChildAfterSuccessfulParentExit(
+            @org.junit.jupiter.api.io.TempDir Path tempDir) throws Exception {
+        String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        Path heartbeat = tempDir.resolve("heartbeat");
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                "-cp", System.getProperty("java.class.path"),
+                BackgroundChildProcess.class.getName(), heartbeat.toString())
+                .redirectErrorStream(true);
+
+        ProcessSupport.CommandResult result = ProcessSupport.runInNewProcessGroup(processBuilder,
+                5, TimeUnit.SECONDS, 1024);
+
+        assertThat(result.finished()).isTrue();
+        assertThat(result.output()).isEqualTo("started");
+        String heartbeatAtCompletion = Files.readString(heartbeat);
+        Thread.sleep(250);
+        assertThat(Files.readString(heartbeat)).isEqualTo(heartbeatAtCompletion);
+    }
+
+    @Test
+    void waitFor_boundsOutputWithoutSplittingUtf8Characters() throws Exception {
+        String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+        Process process = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                "-cp", System.getProperty("java.class.path"), UnicodeOutputProcess.class.getName())
+                .redirectErrorStream(true)
+                .start();
+
+        ProcessSupport.CommandResult result = ProcessSupport.waitFor(process, 5, TimeUnit.SECONDS, 10);
+
+        assertThat(result.output()).isEqualTo("€€€");
+        assertThat(result.output().getBytes(StandardCharsets.UTF_8)).hasSizeLessThanOrEqualTo(10);
+    }
+
+    public static final class SlowOutputProcess {
+        public static void main(String[] args) throws Exception {
+            String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+            new ProcessBuilder(Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                    "-cp", System.getProperty("java.class.path"), SlowOutputChild.class.getName())
+                    .inheritIO()
+                    .start();
+            System.out.print("started");
+            System.out.flush();
+            Thread.sleep(10_000);
+        }
+    }
+
+    public static final class SlowOutputChild {
+        public static void main(String[] args) throws InterruptedException {
+            while (true) {
+                Thread.sleep(1_000);
+            }
+        }
+    }
+
+    public static final class BackgroundChildProcess {
+        public static void main(String[] args) throws Exception {
+            String executable = System.getProperty("os.name").startsWith("Windows") ? "java.exe" : "java";
+            new ProcessBuilder(
+                    Path.of(System.getProperty("java.home"), "bin", executable).toString(),
+                    "-cp", System.getProperty("java.class.path"), BackgroundHeartbeatChild.class.getName(),
+                    args[0])
+                    .inheritIO()
+                    .start();
+            Path heartbeat = Path.of(args[0]);
+            for (int attempt = 0; attempt < 100 && !Files.exists(heartbeat); attempt++) {
+                Thread.sleep(10);
+            }
+            System.out.print("started");
+            System.out.flush();
+        }
+    }
+
+    public static final class BackgroundHeartbeatChild {
+        public static void main(String[] args) throws Exception {
+            Path heartbeat = Path.of(args[0]);
+            while (true) {
+                Files.writeString(heartbeat, Long.toString(System.nanoTime()));
+                Thread.sleep(20);
+            }
+        }
+    }
+
+    public static final class UnicodeOutputProcess {
+        public static void main(String[] args) {
+            System.out.print("€€€€");
+        }
+    }
+}


### PR DESCRIPTION
## What was done and why?

- Added pure-Java hardening for untrusted validation and E2E commands: child processes now run with a scrubbed environment (toolchain allowlist, no application secrets), a dedicated Linux process group via `setsid` where available, descendant tracking with forcible termination, and bounded output with UTF-8-safe truncation.
- Applied the hardened execution path to `ToolExecutionService` (validation tools), `WorkspaceProcessRunner` (E2E `pr-test-run`), and `PrTestWorkspaceManager` (scaffold `npm install`).
- `PrTestWorkspaceManager` now rejects a relative `ai-git-bot.e2e.workspace-root` at construction instead of silently resolving it against the process working directory.
- No container, no daemon, no new configuration: the hardening is always on and requires zero operational changes.

## Testing

- Full Docker Maven test suite green (1432 tests, 0 failures)
- Focused tests for environment scrubbing, process-group isolation, descendant termination, timeouts, output bounds, and the absolute workspace-root validation

### AI use

- Implementation and review used OpenCode (Kimi-K3).