### PR TITLE
encrypt webhook and MCP configuration secrets

### DIFF
--- a/src/main/java/org/remus/giteabot/eventhook/EventHookController.java
+++ b/src/main/java/org/remus/giteabot/eventhook/EventHookController.java
@@ -4,7 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.admin.BotService;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,6 +57,11 @@ public class EventHookController {
         this.objectMapper = objectMapper;
     }
 
+    @InitBinder("endpoint")
+    void disallowEncryptedFieldBinding(WebDataBinder binder) {
+        binder.setDisallowedFields("secret", "authorizationHeader", "customHeaders");
+    }
+
     @GetMapping
     public String list(Model model) {
         model.addAttribute("endpoints", endpointService.findAll());
@@ -85,8 +92,9 @@ public class EventHookController {
     public String save(@ModelAttribute("endpoint") EventHookEndpoint endpoint,
                        @RequestParam(name = "plainSecret", required = false) String plainSecret,
                        @RequestParam(name = "plainAuthorizationHeader", required = false) String plainAuthorizationHeader,
+                       @RequestParam(name = "plainCustomHeaders", required = false) String plainCustomHeaders,
                        Model model, RedirectAttributes redirectAttributes) {
-        String error = validate(endpoint);
+        String error = validate(endpoint, plainCustomHeaders);
         if (error == null && endpoint.getId() != null) {
             // An edit must target an existing endpoint: a forged or stale id is
             // rejected instead of falling into JPA merge semantics.
@@ -105,10 +113,13 @@ public class EventHookController {
             if (plainAuthorizationHeader == null || plainAuthorizationHeader.isBlank()) {
                 endpoint.setAuthorizationHeader(persisted.getAuthorizationHeader());
             }
+            if (plainCustomHeaders == null || plainCustomHeaders.isBlank()) {
+                endpoint.setCustomHeaders(persisted.getCustomHeaders());
+            }
         }
         if (error == null) {
             try {
-                endpointService.save(endpoint, plainSecret, plainAuthorizationHeader);
+                endpointService.save(endpoint, plainSecret, plainAuthorizationHeader, plainCustomHeaders);
                 redirectAttributes.addFlashAttribute("success",
                         "Event hook endpoint '" + endpoint.getName() + "' saved successfully");
                 return REDIRECT_LIST;
@@ -126,7 +137,7 @@ public class EventHookController {
     public String toggle(@PathVariable Long id, RedirectAttributes redirectAttributes) {
         endpointService.findById(id).ifPresentOrElse(endpoint -> {
             endpoint.setEnabled(!endpoint.isEnabled());
-            endpointService.save(endpoint, null, null);
+            endpointService.save(endpoint, null, null, null);
             redirectAttributes.addFlashAttribute("success",
                     "Event hook endpoint '" + endpoint.getName() + "' "
                             + (endpoint.isEnabled() ? "enabled" : "disabled"));
@@ -191,7 +202,7 @@ public class EventHookController {
     }
 
     /** Returns the validation error message, or null when the endpoint is valid. */
-    private String validate(EventHookEndpoint endpoint) {
+    private String validate(EventHookEndpoint endpoint, String plainCustomHeaders) {
         if (endpoint.getName() == null || endpoint.getName().isBlank()) {
             return "Name is required";
         }
@@ -202,10 +213,9 @@ public class EventHookController {
         if (endpoint.getEventTypes() == null || endpoint.getEventTypes().isBlank()) {
             return "Select at least one event type";
         }
-        String headers = endpoint.getCustomHeaders();
-        if (headers != null && !headers.isBlank()) {
+        if (plainCustomHeaders != null && !plainCustomHeaders.isBlank()) {
             try {
-                JsonNode parsed = objectMapper.readTree(headers);
+                JsonNode parsed = objectMapper.readTree(plainCustomHeaders);
                 if (parsed == null || !parsed.isObject()) {
                     return "Custom headers must be a JSON object";
                 }

--- a/src/main/java/org/remus/giteabot/eventhook/EventHookDeliveryWorker.java
+++ b/src/main/java/org/remus/giteabot/eventhook/EventHookDeliveryWorker.java
@@ -123,7 +123,11 @@ public class EventHookDeliveryWorker {
                     .header(EventHookSignatureService.EVENT_HEADER, delivery.getEventType())
                     .header(EventHookSignatureService.DELIVERY_HEADER, delivery.getDeliveryUuid())
                     .headers(h -> {
-                        endpoint.parsedCustomHeaders(objectMapper).forEach(h::add);
+                        // custom_headers are stored encrypted - decrypt only at delivery time.
+                        String customHeadersJson = endpointService.decryptCustomHeaders(endpoint);
+                        if (customHeadersJson != null && !customHeadersJson.isBlank()) {
+                            endpoint.parsedCustomHeaders(objectMapper, customHeadersJson).forEach(h::add);
+                        }
                         // Static Authorization wins over any conflicting custom header.
                         if (authorization != null) {
                             h.set(HttpHeaders.AUTHORIZATION, authorization);

--- a/src/main/java/org/remus/giteabot/eventhook/EventHookEndpoint.java
+++ b/src/main/java/org/remus/giteabot/eventhook/EventHookEndpoint.java
@@ -16,11 +16,12 @@ import java.util.stream.Collectors;
 /**
  * An admin-configured outgoing-webhook endpoint.
  *
- * <p>{@link #secret} and {@link #authorizationHeader} hold
+ * <p>{@link #secret}, {@link #authorizationHeader}, and {@link #customHeaders} hold
  * <strong>encrypted</strong> values (AES-GCM ciphertext, Base64) — never
  * plaintext. Callers that need the plaintext must go through
  * {@link EventHookEndpointService#decryptSecret} /
- * {@link EventHookEndpointService#decryptAuthorizationHeader}. Both are
+ * {@link EventHookEndpointService#decryptAuthorizationHeader} /
+ * {@link EventHookEndpointService#decryptCustomHeaders}. All are
  * optional and independent: unsigned + unauthenticated, signed-only,
  * auth-header-only, or both are all valid configurations.
  *
@@ -64,7 +65,7 @@ public class EventHookEndpoint {
     @Column(nullable = false, length = 1024)
     private String eventTypes;
 
-    /** JSON object of extra HTTP headers sent with every delivery. */
+    /** AES-GCM ciphertext (Base64) of a JSON object of extra HTTP headers. */
     @Column(columnDefinition = "TEXT")
     private String customHeaders;
 
@@ -123,13 +124,13 @@ public class EventHookEndpoint {
         return true;
     }
 
-    /** Parses {@link #customHeaders} as a JSON object; empty map on missing/invalid content. */
-    public Map<String, String> parsedCustomHeaders(ObjectMapper mapper) {
-        if (customHeaders == null || customHeaders.isBlank()) {
+    /** Parses the given raw JSON as a headers object; empty map on missing/invalid content. */
+    public Map<String, String> parsedCustomHeaders(ObjectMapper mapper, String rawJson) {
+        if (rawJson == null || rawJson.isBlank()) {
             return Map.of();
         }
         try {
-            Map<String, String> parsed = mapper.readValue(customHeaders, new TypeReference<>() {
+            Map<String, String> parsed = mapper.readValue(rawJson, new TypeReference<>() {
             });
             return parsed == null ? Map.of() : parsed;
         } catch (Exception e) {

--- a/src/main/java/org/remus/giteabot/eventhook/EventHookEndpointService.java
+++ b/src/main/java/org/remus/giteabot/eventhook/EventHookEndpointService.java
@@ -34,18 +34,28 @@ public class EventHookEndpointService {
         return endpointRepository.findById(id);
     }
 
-    /**
-     * Blank credential inputs on edit mean "keep current" (mirrors the
-     * ai-integrations form contract). Both credentials are optional: an
-     * endpoint may have neither, either, or both.
-     */
+    /** Backwards-compatible overload without custom headers. */
     public EventHookEndpoint save(EventHookEndpoint endpoint,
                                   String plainSecret, String plainAuthorizationHeader) {
+        return save(endpoint, plainSecret, plainAuthorizationHeader, null);
+    }
+
+    /**
+     * Blank credential inputs on edit mean "keep current" (mirrors the
+     * ai-integrations form contract). All three credentials are optional: an
+     * endpoint may have none, any, or all of them.
+     */
+    public EventHookEndpoint save(EventHookEndpoint endpoint,
+                                  String plainSecret, String plainAuthorizationHeader,
+                                  String plainCustomHeaders) {
         if (plainSecret != null && !plainSecret.isBlank()) {
             endpoint.setSecret(encryptionService.encrypt(plainSecret));
         }
         if (plainAuthorizationHeader != null && !plainAuthorizationHeader.isBlank()) {
             endpoint.setAuthorizationHeader(encryptionService.encrypt(plainAuthorizationHeader));
+        }
+        if (plainCustomHeaders != null && !plainCustomHeaders.isBlank()) {
+            endpoint.setCustomHeaders(encryptionService.encrypt(plainCustomHeaders));
         }
         return endpointRepository.save(endpoint);
     }
@@ -64,5 +74,11 @@ public class EventHookEndpointService {
     public String decryptAuthorizationHeader(EventHookEndpoint endpoint) {
         String header = endpoint.getAuthorizationHeader();
         return (header == null || header.isBlank()) ? null : encryptionService.decrypt(header);
+    }
+
+    /** Plaintext custom-headers JSON object, or null when unset. */
+    public String decryptCustomHeaders(EventHookEndpoint endpoint) {
+        String headers = endpoint.getCustomHeaders();
+        return (headers == null || headers.isBlank()) ? null : encryptionService.decrypt(headers);
     }
 }

--- a/src/main/java/org/remus/giteabot/mcp/McpOrchestrationService.java
+++ b/src/main/java/org/remus/giteabot/mcp/McpOrchestrationService.java
@@ -9,6 +9,7 @@ import io.modelcontextprotocol.client.transport.HttpClientStreamableHttpTranspor
 import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.ProtocolVersions;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.remus.giteabot.admin.EncryptionService;
 import org.remus.giteabot.agent.validation.ToolResult;
@@ -32,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class McpOrchestrationService {
 
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(20);
@@ -50,10 +52,6 @@ public class McpOrchestrationService {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<CacheKey, McpToolCatalog> toolCache = new ConcurrentHashMap<>();
     private final EncryptionService encryptionService;
-
-    public McpOrchestrationService(EncryptionService encryptionService) {
-        this.encryptionService = encryptionService;
-    }
 
     /** The MCP configuration JSON is stored encrypted - decrypt before parsing. */
     private String decryptedJson(McpConfiguration configuration) {
@@ -83,7 +81,7 @@ public class McpOrchestrationService {
         if (toolDefinition == null) {
             return new ToolResult(false, -1, "", "MCP tool '" + qualifiedToolName + "' is not available");
         }
-        McpServerDefinition server = serverDiscovery.discover(decryptedJson(configuration)).stream()
+        McpServerDefinition server = discoverServers(configuration).stream()
                 .filter(definition -> sanitizeName(definition.name()).equals(toolDefinition.serverName()))
                 .findFirst()
                 .orElse(null);
@@ -124,11 +122,15 @@ public class McpOrchestrationService {
     }
 
     private McpToolCatalog fetchToolCatalog(McpConfiguration configuration) {
-        List<McpToolDefinition> tools = serverDiscovery.discover(decryptedJson(configuration)).stream()
+        List<McpToolDefinition> tools = discoverServers(configuration).stream()
                 .flatMap(server -> fetchServerTools(server).stream())
                 .toList();
         log.info("Discovered {} MCP tools for configuration '{}'", tools.size(), configuration.getName());
         return new McpToolCatalog(tools);
+    }
+
+    List<McpServerDefinition> discoverServers(McpConfiguration configuration) {
+        return configuration == null ? List.of() : serverDiscovery.discover(decryptedJson(configuration));
     }
 
     private List<McpToolDefinition> fetchServerTools(McpServerDefinition server) {
@@ -486,4 +488,3 @@ public class McpOrchestrationService {
         }
     }
 }
-

--- a/src/main/java/org/remus/giteabot/mcp/McpOrchestrationService.java
+++ b/src/main/java/org/remus/giteabot/mcp/McpOrchestrationService.java
@@ -10,6 +10,7 @@ import io.modelcontextprotocol.spec.McpClientTransport;
 import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.ProtocolVersions;
 import lombok.extern.slf4j.Slf4j;
+import org.remus.giteabot.admin.EncryptionService;
 import org.remus.giteabot.agent.validation.ToolResult;
 import org.remus.giteabot.systemsettings.McpConfiguration;
 import org.springframework.stereotype.Service;
@@ -48,6 +49,17 @@ public class McpOrchestrationService {
     private final McpServerDiscovery serverDiscovery = new McpServerDiscovery(configurationParser);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Map<CacheKey, McpToolCatalog> toolCache = new ConcurrentHashMap<>();
+    private final EncryptionService encryptionService;
+
+    public McpOrchestrationService(EncryptionService encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
+    /** The MCP configuration JSON is stored encrypted - decrypt before parsing. */
+    private String decryptedJson(McpConfiguration configuration) {
+        String json = configuration.getJsonContent();
+        return (json == null || json.isBlank()) ? json : encryptionService.decrypt(json);
+    }
 
     public McpToolCatalog discoverTools(McpConfiguration configuration) {
         if (configuration == null) {
@@ -71,7 +83,7 @@ public class McpOrchestrationService {
         if (toolDefinition == null) {
             return new ToolResult(false, -1, "", "MCP tool '" + qualifiedToolName + "' is not available");
         }
-        McpServerDefinition server = serverDiscovery.discover(configuration).stream()
+        McpServerDefinition server = serverDiscovery.discover(decryptedJson(configuration)).stream()
                 .filter(definition -> sanitizeName(definition.name()).equals(toolDefinition.serverName()))
                 .findFirst()
                 .orElse(null);
@@ -112,7 +124,7 @@ public class McpOrchestrationService {
     }
 
     private McpToolCatalog fetchToolCatalog(McpConfiguration configuration) {
-        List<McpToolDefinition> tools = serverDiscovery.discover(configuration).stream()
+        List<McpToolDefinition> tools = serverDiscovery.discover(decryptedJson(configuration)).stream()
                 .flatMap(server -> fetchServerTools(server).stream())
                 .toList();
         log.info("Discovered {} MCP tools for configuration '{}'", tools.size(), configuration.getName());
@@ -474,5 +486,4 @@ public class McpOrchestrationService {
         }
     }
 }
-
 

--- a/src/main/java/org/remus/giteabot/mcp/McpServerDiscovery.java
+++ b/src/main/java/org/remus/giteabot/mcp/McpServerDiscovery.java
@@ -1,7 +1,5 @@
 package org.remus.giteabot.mcp;
 
-import org.remus.giteabot.systemsettings.McpConfiguration;
-
 import java.util.List;
 
 public class McpServerDiscovery {
@@ -12,11 +10,15 @@ public class McpServerDiscovery {
         this.configurationParser = configurationParser;
     }
 
-    public List<McpServerDefinition> discover(McpConfiguration configuration) {
-        if (configuration == null) {
+    /**
+     * Parses the (already decrypted) MCP configuration JSON into server
+     * definitions with a non-blank URL.
+     */
+    public List<McpServerDefinition> discover(String jsonContent) {
+        if (jsonContent == null || jsonContent.isBlank()) {
             return List.of();
         }
-        return configurationParser.parse(configuration.getJsonContent()).stream()
+        return configurationParser.parse(jsonContent).stream()
                 .filter(server -> server.url() != null && !server.url().isBlank())
                 .toList();
     }

--- a/src/main/java/org/remus/giteabot/systemsettings/McpConfigurationService.java
+++ b/src/main/java/org/remus/giteabot/systemsettings/McpConfigurationService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.remus.giteabot.admin.Bot;
 import org.remus.giteabot.admin.BotRepository;
+import org.remus.giteabot.admin.EncryptionService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +21,7 @@ public class McpConfigurationService {
 
     private final McpConfigurationRepository mcpConfigurationRepository;
     private final BotRepository botRepository;
+    private final EncryptionService encryptionService;
 
     @Transactional(readOnly = true)
     public List<McpConfiguration> findAll() {
@@ -31,6 +33,12 @@ public class McpConfigurationService {
         return mcpConfigurationRepository.findById(id);
     }
 
+    /**
+     * Validates and persists the configuration. The JSON content may contain
+     * MCP server credentials (authorization tokens, custom headers), so it is
+     * stored encrypted via {@link EncryptionService}. The incoming value is
+     * always plaintext (e.g. from the admin form).
+     */
     public McpConfiguration save(McpConfiguration mcpConfiguration) {
         if (mcpConfiguration.getName() == null || mcpConfiguration.getName().isBlank()) {
             throw new IllegalArgumentException("Name is required");
@@ -46,7 +54,28 @@ public class McpConfigurationService {
         if (duplicateName) {
             throw new IllegalArgumentException("An MCP configuration with this name already exists");
         }
+        mcpConfiguration.setJsonContent(encryptionService.encrypt(mcpConfiguration.getJsonContent()));
         return mcpConfigurationRepository.save(mcpConfiguration);
+    }
+
+    /** Decrypted JSON content of the configuration (may contain credentials). */
+    @Transactional(readOnly = true)
+    public String getDecryptedJsonContent(McpConfiguration configuration) {
+        String json = configuration.getJsonContent();
+        return (json == null || json.isBlank()) ? json : encryptionService.decrypt(json);
+    }
+
+    /**
+     * Returns a transient copy of the configuration with decrypted JSON
+     * content, for rendering in the admin edit form. Never persisted.
+     */
+    @Transactional(readOnly = true)
+    public McpConfiguration decryptedView(McpConfiguration configuration) {
+        McpConfiguration copy = new McpConfiguration();
+        copy.setId(configuration.getId());
+        copy.setName(configuration.getName());
+        copy.setJsonContent(getDecryptedJsonContent(configuration));
+        return copy;
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/org/remus/giteabot/systemsettings/SystemSettingsController.java
+++ b/src/main/java/org/remus/giteabot/systemsettings/SystemSettingsController.java
@@ -59,7 +59,8 @@ public class SystemSettingsController {
     public String editMcpForm(@PathVariable Long id, Model model, RedirectAttributes redirectAttributes) {
         return mcpConfigurationService.findById(id)
                 .map(mcpConfiguration -> {
-                    model.addAttribute("mcpConfiguration", mcpConfiguration);
+                    // The stored JSON is encrypted - render the decrypted view in the form.
+                    model.addAttribute("mcpConfiguration", mcpConfigurationService.decryptedView(mcpConfiguration));
                     model.addAttribute("activeNav", "system-settings");
                     return "system-settings/mcp-form";
                 })

--- a/src/main/resources/templates/event-hooks/form.html
+++ b/src/main/resources/templates/event-hooks/form.html
@@ -49,9 +49,10 @@
 
             <div class="mb-3">
                 <label class="form-label">Custom headers (JSON object, optional)</label>
-                <textarea class="form-control font-monospace" rows="3" th:field="*{customHeaders}"
-                          placeholder='{ "X-Source": "ai-git-bot" }'></textarea>
-                <div class="form-text">Sent with every delivery. Must be a single JSON object.</div>
+                <textarea class="form-control font-monospace" rows="3" name="plainCustomHeaders"
+                          th:placeholder="${endpoint.customHeaders != null} ? 'configured - leave blank to keep' : '{ &quot;X-Source&quot;: &quot;ai-git-bot&quot; }'"></textarea>
+                <div class="form-text">Sent with every delivery. Must be a single JSON object. Stored
+                    encrypted; leave blank on edit to keep the current value.</div>
             </div>
 
             <div class="row">

--- a/src/test/java/org/remus/giteabot/eventhook/EventHookControllerTest.java
+++ b/src/test/java/org/remus/giteabot/eventhook/EventHookControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,6 +39,8 @@ class EventHookControllerTest {
     private WebApplicationContext wac;
     @Autowired
     private EventHookEndpointRepository endpointRepository;
+    @Autowired
+    private EventHookEndpointService endpointService;
     @Autowired
     private EventHookDeliveryRepository deliveryRepository;
 
@@ -132,6 +135,24 @@ class EventHookControllerTest {
         assertNull(endpoint.getSecret());
         assertNull(endpoint.getAuthorizationHeader());
         assertNull(endpoint.getCustomHeaders());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void saveWithPlainCustomHeadersEncryptsTheirStoredValue() throws Exception {
+        String customHeaders = "{\"X-Api-Key\":\"token123456\"}";
+
+        mvc.perform(post("/admin/event-hooks/save").with(csrf())
+                        .param("name", "Encrypted headers")
+                        .param("url", "https://example.com/hook")
+                        .param("eventTypes", "PR_WORKFLOW_STARTED")
+                        .param("plainCustomHeaders", customHeaders))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/event-hooks"));
+
+        EventHookEndpoint endpoint = endpointRepository.findAll().getFirst();
+        assertNotEquals(customHeaders, endpoint.getCustomHeaders());
+        assertEquals(customHeaders, endpointService.decryptCustomHeaders(endpoint));
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/eventhook/EventHookControllerTest.java
+++ b/src/test/java/org/remus/giteabot/eventhook/EventHookControllerTest.java
@@ -117,6 +117,25 @@ class EventHookControllerTest {
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    void saveIgnoresDirectBindingOfEncryptedFields() throws Exception {
+        mvc.perform(post("/admin/event-hooks/save").with(csrf())
+                        .param("name", "Protected fields")
+                        .param("url", "https://example.com/hook")
+                        .param("eventTypes", "PR_WORKFLOW_STARTED")
+                        .param("secret", "plain-secret")
+                        .param("authorizationHeader", "Bearer token123456")
+                        .param("customHeaders", "{\"X-Api-Key\":\"token123456\"}"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/admin/event-hooks"));
+
+        EventHookEndpoint endpoint = endpointRepository.findAll().getFirst();
+        assertNull(endpoint.getSecret());
+        assertNull(endpoint.getAuthorizationHeader());
+        assertNull(endpoint.getCustomHeaders());
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
     void toggleFlipsEnabledFlag() throws Exception {
         EventHookEndpoint endpoint = endpointRepository.save(endpoint("Toggle me", "https://example.com/hook"));
         assertTrue(endpoint.isEnabled());

--- a/src/test/java/org/remus/giteabot/eventhook/EventHookDeliveryWorkerTest.java
+++ b/src/test/java/org/remus/giteabot/eventhook/EventHookDeliveryWorkerTest.java
@@ -155,10 +155,10 @@ class EventHookDeliveryWorkerTest {
     }
 
     @Test
-    void deliver_authorizationHeader_sentVerbatimAndOverridesCustomHeader() {
+    void deliver_encryptedCustomHeadersAndAuthorizationHeader() {
         EventHookEndpoint endpoint = endpoint(false);
         endpoint.setAuthorizationHeader(encryptionService.encrypt("Bearer token123456"));
-        endpoint.setCustomHeaders("{\"Authorization\": \"Bearer wrong\", \"X-Custom\": \"yes\"}");
+        endpoint.setCustomHeaders(encryptionService.encrypt("{\"Authorization\": \"Bearer wrong\", \"X-Custom\": \"yes\"}"));
         EventHookDelivery delivery = delivery(endpoint);
         stubLoad(delivery, endpoint);
 

--- a/src/test/java/org/remus/giteabot/eventhook/EventHookEndpointServiceTest.java
+++ b/src/test/java/org/remus/giteabot/eventhook/EventHookEndpointServiceTest.java
@@ -48,6 +48,16 @@ class EventHookEndpointServiceTest {
     }
 
     @Test
+    void save_encryptsCustomHeaders_andDecryptsThemForDelivery() {
+        String customHeaders = "{\"X-Api-Key\":\"token123456\"}";
+
+        EventHookEndpoint saved = service.save(new EventHookEndpoint(), null, null, customHeaders);
+
+        assertNotEquals(customHeaders, saved.getCustomHeaders());
+        assertEquals(customHeaders, service.decryptCustomHeaders(saved));
+    }
+
+    @Test
     void save_blankCredentialsOnEdit_keepExistingCiphertext() {
         EventHookEndpoint endpoint = service.save(new EventHookEndpoint(), "plain-secret", "Bearer token123456");
         String secretCiphertext = endpoint.getSecret();
@@ -70,6 +80,16 @@ class EventHookEndpointServiceTest {
 
         assertEquals(secretCiphertext, resaved.getSecret());
         assertEquals(authCiphertext, resaved.getAuthorizationHeader());
+    }
+
+    @Test
+    void save_blankCustomHeadersOnEdit_keepsExistingCiphertext() {
+        EventHookEndpoint endpoint = service.save(new EventHookEndpoint(), null, null, "{\"X-Test\":\"value\"}");
+        String customHeadersCiphertext = endpoint.getCustomHeaders();
+
+        EventHookEndpoint resaved = service.save(endpoint, null, null, "  ");
+
+        assertEquals(customHeadersCiphertext, resaved.getCustomHeaders());
     }
 
     @Test

--- a/src/test/java/org/remus/giteabot/eventhook/EventHookEndpointTest.java
+++ b/src/test/java/org/remus/giteabot/eventhook/EventHookEndpointTest.java
@@ -137,27 +137,23 @@ class EventHookEndpointTest {
 
     @Test
     void parsedCustomHeaders_validJson_returnsMap() {
-        EventHookEndpoint endpoint = endpoint("PR_WORKFLOW_STARTED");
-        endpoint.setCustomHeaders("{\"X-Team\":\"infra\",\"X-Env\":\"prod\"}");
-
         assertEquals(Map.of("X-Team", "infra", "X-Env", "prod"),
-                endpoint.parsedCustomHeaders(objectMapper));
+                endpoint("PR_WORKFLOW_STARTED").parsedCustomHeaders(objectMapper,
+                        "{\"X-Team\":\"infra\",\"X-Env\":\"prod\"}"));
     }
 
     @Test
     void parsedCustomHeaders_nullOrBlank_returnsEmpty() {
-        assertTrue(endpoint("PR_WORKFLOW_STARTED").parsedCustomHeaders(objectMapper).isEmpty());
+        EventHookEndpoint endpoint = endpoint("PR_WORKFLOW_STARTED");
 
-        EventHookEndpoint blank = endpoint("PR_WORKFLOW_STARTED");
-        blank.setCustomHeaders("  ");
-        assertTrue(blank.parsedCustomHeaders(objectMapper).isEmpty());
+        assertTrue(endpoint.parsedCustomHeaders(objectMapper, null).isEmpty());
+        assertTrue(endpoint.parsedCustomHeaders(objectMapper, "  ").isEmpty());
     }
 
     @Test
     void parsedCustomHeaders_invalidJson_returnsEmpty() {
         EventHookEndpoint endpoint = endpoint("PR_WORKFLOW_STARTED");
-        endpoint.setCustomHeaders("{not json");
 
-        assertTrue(endpoint.parsedCustomHeaders(objectMapper).isEmpty());
+        assertTrue(endpoint.parsedCustomHeaders(objectMapper, "{not json").isEmpty());
     }
 }

--- a/src/test/java/org/remus/giteabot/mcp/McpConfigurationParserTest.java
+++ b/src/test/java/org/remus/giteabot/mcp/McpConfigurationParserTest.java
@@ -63,7 +63,7 @@ class McpConfigurationParserTest {
                 """);
         McpServerDiscovery discovery = new McpServerDiscovery(parser);
 
-        List<McpServerDefinition> servers = discovery.discover(configuration);
+        List<McpServerDefinition> servers = discovery.discover(configuration.getJsonContent());
 
         assertEquals(1, servers.size());
         assertEquals("remote", servers.getFirst().name());

--- a/src/test/java/org/remus/giteabot/mcp/McpOrchestrationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/mcp/McpOrchestrationServiceTest.java
@@ -1,6 +1,8 @@
 package org.remus.giteabot.mcp;
 
 import org.junit.jupiter.api.Test;
+import org.remus.giteabot.admin.EncryptionService;
+import org.remus.giteabot.systemsettings.McpConfiguration;
 
 import java.net.http.HttpClient;
 import java.util.List;
@@ -12,8 +14,21 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpOrchestrationServiceTest {
 
-    private final McpOrchestrationService service = new McpOrchestrationService(
-            new org.remus.giteabot.admin.EncryptionService("test-key"));
+    private final EncryptionService encryptionService = new EncryptionService("test-key");
+    private final McpOrchestrationService service = new McpOrchestrationService(encryptionService);
+
+    @Test
+    void discoverServers_decryptsPersistedConfiguration() {
+        McpConfiguration configuration = new McpConfiguration();
+        configuration.setJsonContent(encryptionService.encrypt("""
+                [{"name":"github","type":"url","url":"https://example.test/mcp"}]
+                """));
+
+        List<McpServerDefinition> servers = service.discoverServers(configuration);
+
+        assertEquals(1, servers.size());
+        assertEquals("github", servers.getFirst().name());
+    }
 
     @Test
     void resolveTransportEndpoint_streamableHttpUsesConfiguredMcpEndpointWithoutTrailingSlash() {
@@ -77,4 +92,3 @@ class McpOrchestrationServiceTest {
         assertTrue(attempts.stream().anyMatch(attempt -> attempt.protocolVersions().equals(List.of("2024-11-05"))));
     }
 }
-

--- a/src/test/java/org/remus/giteabot/mcp/McpOrchestrationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/mcp/McpOrchestrationServiceTest.java
@@ -12,7 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpOrchestrationServiceTest {
 
-    private final McpOrchestrationService service = new McpOrchestrationService();
+    private final McpOrchestrationService service = new McpOrchestrationService(
+            new org.remus.giteabot.admin.EncryptionService("test-key"));
 
     @Test
     void resolveTransportEndpoint_streamableHttpUsesConfiguredMcpEndpointWithoutTrailingSlash() {

--- a/src/test/java/org/remus/giteabot/systemsettings/McpConfigurationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/systemsettings/McpConfigurationServiceTest.java
@@ -4,9 +4,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.remus.giteabot.admin.Bot;
 import org.remus.giteabot.admin.BotRepository;
+import org.remus.giteabot.admin.EncryptionService;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +24,10 @@ class McpConfigurationServiceTest {
 
     @Mock
     private BotRepository botRepository;
+
+    /** Real encryption with a test key so save() encrypts the JSON content. */
+    @Spy
+    private EncryptionService encryptionService = new EncryptionService("test-key");
 
     @InjectMocks
     private McpConfigurationService mcpConfigurationService;
@@ -52,14 +58,18 @@ class McpConfigurationServiceTest {
 
     @Test
     void save_acceptsRemoteTransport() {
-        McpConfiguration mcpConfiguration = configuration("""
+        String jsonContent = """
                 {"name":"github","type":"url","url":"https://api.githubcopilot.com/mcp/"}
-                """);
+                """;
+        McpConfiguration mcpConfiguration = configuration(jsonContent);
         when(mcpConfigurationRepository.save(mcpConfiguration)).thenReturn(mcpConfiguration);
 
         McpConfiguration result = mcpConfigurationService.save(mcpConfiguration);
 
         assertSame(mcpConfiguration, result);
+        assertNotEquals(jsonContent, result.getJsonContent());
+        assertEquals(jsonContent, mcpConfigurationService.getDecryptedJsonContent(result));
+        assertEquals(jsonContent, mcpConfigurationService.decryptedView(result).getJsonContent());
         verify(mcpConfigurationRepository).save(mcpConfiguration);
     }
 

--- a/src/test/java/org/remus/giteabot/systemsettings/SystemSettingsControllerTest.java
+++ b/src/test/java/org/remus/giteabot/systemsettings/SystemSettingsControllerTest.java
@@ -58,6 +58,29 @@ class SystemSettingsControllerTest {
     }
 
     @Test
+    void editMcpForm_usesDecryptedConfigurationView() {
+        McpConfigurationService mcpConfigurationService = mock(McpConfigurationService.class);
+        SystemSettingsController controller = newController(mock(SystemPromptService.class),
+                mcpConfigurationService, mock(McpToolSelectionService.class),
+                mock(BotToolConfigurationService.class), mock(BotToolSelectionService.class));
+        McpConfiguration encryptedConfiguration = new McpConfiguration();
+        encryptedConfiguration.setId(5L);
+        encryptedConfiguration.setJsonContent("ciphertext");
+        McpConfiguration decryptedConfiguration = new McpConfiguration();
+        decryptedConfiguration.setId(5L);
+        decryptedConfiguration.setJsonContent("{\"url\":\"https://example.test/mcp\"}");
+        when(mcpConfigurationService.findById(5L)).thenReturn(Optional.of(encryptedConfiguration));
+        when(mcpConfigurationService.decryptedView(encryptedConfiguration)).thenReturn(decryptedConfiguration);
+        ConcurrentModel model = new ConcurrentModel();
+
+        String view = controller.editMcpForm(5L, model, new RedirectAttributesModelMap());
+
+        assertEquals("system-settings/mcp-form", view);
+        assertEquals(decryptedConfiguration, model.getAttribute("mcpConfiguration"));
+        verify(mcpConfigurationService).decryptedView(encryptedConfiguration);
+    }
+
+    @Test
     void saveMcpToolSelection_persistsSelectionAndRedirects() {
         McpToolSelectionService mcpToolSelectionService = mock(McpToolSelectionService.class);
         SystemSettingsController controller = newController(mock(SystemPromptService.class),


### PR DESCRIPTION
## What was done and why?

- Encrypts outgoing event-hook custom-header JSON and MCP configuration JSON with the existing `EncryptionService` before persistence when `APP_ENCRYPTION_KEY` is configured.
- Decrypts values only at the event-hook delivery, MCP discovery/execution, and admin edit boundaries.
- Blocks direct request binding of encrypted event-hook fields so plaintext cannot bypass the encryption path.
- Preserves readable legacy plaintext and encrypts it when the configuration is next saved.
- Adds focused coverage for encrypted persistence, delivery, form binding, MCP discovery, and decrypted edit views.

## Testing

- Focused Event Hook and MCP test suite: 72 tests
- Git whitespace validation

### AI use

- Initial implementation used KIMI K3; the split, hardening, and review used OpenCode (gpt-5.6-terra).