### PR TITLE
fail closed invalid login configuration

### DIFF
--- a/src/main/java/org/remus/giteabot/admin/LoginMethodValidator.java
+++ b/src/main/java/org/remus/giteabot/admin/LoginMethodValidator.java
@@ -1,0 +1,22 @@
+package org.remus.giteabot.admin;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Fail-fast validation of the web login method. A typo in
+ * {@code giteabot.security.login-method} must not silently leave the app
+ * without any web security chain (fail-open) - refuse to start instead.
+ */
+@Configuration
+public class LoginMethodValidator {
+
+    public LoginMethodValidator(
+            @Value("${giteabot.security.login-method:native}") String loginMethod) {
+        if (!"native".equals(loginMethod) && !"oauth".equals(loginMethod)) {
+            throw new IllegalStateException(
+                    "Invalid giteabot.security.login-method: '" + loginMethod
+                            + "'. Must be 'native' or 'oauth'. Refusing to start without a defined web security chain.");
+        }
+    }
+}

--- a/src/main/java/org/remus/giteabot/admin/OAuthLoginController.java
+++ b/src/main/java/org/remus/giteabot/admin/OAuthLoginController.java
@@ -28,6 +28,7 @@ public class OAuthLoginController {
         return "oauth-login-error";
     }
 
+    /** Displays the public confirmation page after a local OAuth logout. */
     @GetMapping("/signed-out")
     public String signedOut() {
         return "signed-out";

--- a/src/main/java/org/remus/giteabot/admin/OAuthLoginController.java
+++ b/src/main/java/org/remus/giteabot/admin/OAuthLoginController.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
-/** Displays OAuth failures without routing back through the provider-login entry point. */
+/** Displays OAuth status pages without routing back through the provider-login entry point. */
 @Slf4j
 @Controller
 @ConditionalOnProperty(prefix = "giteabot.security", name = "login-method", havingValue = "oauth")
@@ -26,5 +26,10 @@ public class OAuthLoginController {
         }
         model.addAttribute("error", "OAuth sign-in failed. Check the server logs and your OAuth client configuration, then try again.");
         return "oauth-login-error";
+    }
+
+    @GetMapping("/signed-out")
+    public String signedOut() {
+        return "signed-out";
     }
 }

--- a/src/main/java/org/remus/giteabot/admin/SecurityConfig.java
+++ b/src/main/java/org/remus/giteabot/admin/SecurityConfig.java
@@ -101,7 +101,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico",
-                                "/oauth2/**", "/login/oauth2/**").permitAll()
+                                "/oauth2/**", "/login/oauth2/**", "/signed-out").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth -> oauth
@@ -118,7 +118,7 @@ public class SecurityConfig {
                                 "/oauth2/authorization/" + OAuthLoginConfiguration.REGISTRATION_ID))
                 )
                 .logout(logout -> logout
-                        .logoutSuccessUrl("/")
+                        .logoutSuccessUrl("/signed-out")
                         .permitAll()
                 );
 

--- a/src/main/resources/templates/signed-out.html
+++ b/src/main/resources/templates/signed-out.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>Signed out - AI Git Bot</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
+    <link rel="icon" type="image/png" th:href="@{/images/favicon.png}"/>
+    <script th:src="@{/js/theme-init.js}"></script>
+</head>
+<body class="bg-body-tertiary">
+    <main class="container d-flex align-items-center justify-content-center" style="min-height: 100vh;">
+        <div class="col-md-6 col-lg-5">
+            <section class="card shadow">
+                <div class="card-body p-4 text-center">
+                    <img th:src="@{/images/favicon.png}" alt="AI Git Bot logo" width="64" height="64" class="mb-3 brand-icon"/>
+                    <h1 class="h3">You have signed out</h1>
+                    <p class="text-secondary mb-4">Your AI Git Bot session has ended.</p>
+                    <a th:href="@{/oauth2/authorization/giteabot}" class="btn btn-primary">
+                        <i class="bi bi-box-arrow-in-right"></i> Sign in again
+                    </a>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/src/test/java/org/remus/giteabot/admin/LoginMethodValidatorTest.java
+++ b/src/test/java/org/remus/giteabot/admin/LoginMethodValidatorTest.java
@@ -1,0 +1,24 @@
+package org.remus.giteabot.admin;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LoginMethodValidatorTest {
+
+    @Test
+    void acceptsSupportedLoginMethods() {
+        assertDoesNotThrow(() -> new LoginMethodValidator("native"));
+        assertDoesNotThrow(() -> new LoginMethodValidator("oauth"));
+    }
+
+    @Test
+    void rejectsUnsupportedLoginMethods() {
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> new LoginMethodValidator("disabled"));
+
+        assertTrue(exception.getMessage().contains("Invalid giteabot.security.login-method"));
+    }
+}

--- a/src/test/java/org/remus/giteabot/admin/OAuthSecurityMvcTest.java
+++ b/src/test/java/org/remus/giteabot/admin/OAuthSecurityMvcTest.java
@@ -19,7 +19,10 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -49,6 +52,20 @@ class OAuthSecurityMvcTest {
         mockMvc.perform(get("/oauth2/error"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("oauth-login-error"));
+    }
+
+    @Test
+    void logoutRedirectsToSignedOutPageInsteadOfRestartingOAuth() throws Exception {
+        mockMvc.perform(post("/logout").with(user("admin")).with(csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/signed-out"));
+    }
+
+    @Test
+    void signedOutPageIsAccessibleWithoutStartingAnotherLogin() throws Exception {
+        mockMvc.perform(get("/signed-out"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("signed-out"));
     }
 
     @Controller


### PR DESCRIPTION
## What was done and why?

- Validates `giteabot.security.login-method` during startup and aborts for every value except `native` and `oauth`, preventing an undefined web-security configuration.
- Redirects local OAuth logout to a public `/signed-out` page instead of immediately re-entering the provider-login flow.
- Adds coverage for supported and unsupported login methods, logout redirect behavior, and anonymous access to the signed-out page.

## Testing

- Focused login and OAuth MVC suite: 6 tests
- Git whitespace validation

### AI use

- Initial implementation used KIMI K3; the split, hardening, and review used OpenCode (gpt-5.6-terra).