### PR TITLE
fix(admin): stop re-encrypting API keys when editing AI integrations

### DIFF
--- a/src/main/java/org/remus/giteabot/admin/AiIntegrationController.java
+++ b/src/main/java/org/remus/giteabot/admin/AiIntegrationController.java
@@ -61,17 +61,17 @@ public class AiIntegrationController {
     @PostMapping("/save")
     public String save(@ModelAttribute AiIntegration integration,
                        @RequestParam(required = false) String apiKey,
+                       @RequestParam(required = false, defaultValue = "false") boolean clearApiKey,
                        RedirectAttributes redirectAttributes) {
         try {
-            // If editing an existing integration and no new API key provided,
-            // keep the existing encrypted API key
-            if (integration.getId() != null && (apiKey == null || apiKey.isBlank())) {
-                aiIntegrationService.findById(integration.getId())
-                        .ifPresent(existing -> integration.setApiKey(existing.getApiKey()));
-            } else {
+            // The key form field is a one-way write: only override when a new
+            // key is provided. Blank means "keep the stored key" and the
+            // explicit Clear button requests removal - both resolved in the
+            // service so the kept ciphertext is never re-encrypted.
+            if (apiKey != null && !apiKey.isBlank()) {
                 integration.setApiKey(apiKey);
             }
-            aiIntegrationService.save(integration);
+            aiIntegrationService.save(integration, clearApiKey);
             redirectAttributes.addFlashAttribute("success", "AI Integration saved successfully");
         } catch (Exception e) {
             log.error("Failed to save AI Integration", e);

--- a/src/main/java/org/remus/giteabot/admin/AiIntegrationService.java
+++ b/src/main/java/org/remus/giteabot/admin/AiIntegrationService.java
@@ -28,9 +28,27 @@ public class AiIntegrationService {
     }
 
     public AiIntegration save(AiIntegration integration) {
+        return save(integration, false);
+    }
+
+    /**
+     * Saves an AI integration, resolving the API key from the form input.
+     *
+     * <p>The key field is a one-way write: the stored value is never echoed
+     * back into the form. A blank field therefore means "keep the stored
+     * value", while {@code clearApiKey} requests explicit removal (the Clear
+     * button in the UI). Re-encrypting the kept ciphertext would corrupt the
+     * key, so only freshly provided plaintext keys are encrypted.</p>
+     */
+    public AiIntegration save(AiIntegration integration, boolean clearApiKey) {
         String apiKey = integration.getApiKey();
         if (apiKey != null && !apiKey.isBlank()) {
             integration.setApiKey(encryptionService.encrypt(apiKey));
+        } else if (clearApiKey) {
+            integration.setApiKey(null);
+        } else if (integration.getId() != null) {
+            aiIntegrationRepository.findById(integration.getId())
+                    .ifPresent(existing -> integration.setApiKey(existing.getApiKey()));
         }
         return aiIntegrationRepository.save(integration);
     }

--- a/src/main/resources/templates/ai-integrations/form.html
+++ b/src/main/resources/templates/ai-integrations/form.html
@@ -42,8 +42,17 @@
                         </div>
                         <div class="col-md-6">
                             <label for="apiKey" class="form-label">API Key</label>
-                            <input type="password" class="form-control" id="apiKey" name="apiKey"
-                                    placeholder="Enter API key"/>
+                            <div class="input-group">
+                                <input type="password" class="form-control" id="apiKey" name="apiKey"
+                                        autocomplete="new-password"
+                                        placeholder="Enter API key"/>
+                                <button class="btn btn-outline-secondary" type="button" id="clearApiKeyBtn"
+                                        th:if="${integration.id != null}"
+                                        title="Remove the stored API key">
+                                    <i class="bi bi-trash"></i> Clear
+                                </button>
+                            </div>
+                            <input type="hidden" id="clearApiKey" name="clearApiKey" value="false"/>
                             <div class="form-text" id="apiKeyHint"></div>
                             <div th:if="${integration.id != null}" class="form-text">
                                 Leave blank to keep current API key.
@@ -244,6 +253,18 @@
                 if (providerSelect.value) {
                     providerSelect.dataset.previousValue = providerSelect.value;
                     updateProviderDefaults();
+                }
+
+                // ---- API key: remember that the operator wants it removed on
+                // save (an empty field alone means "keep the stored value", so
+                // we need an explicit marker). ----
+                const clearApiKeyBtn = document.getElementById('clearApiKeyBtn');
+                if (clearApiKeyBtn) {
+                    clearApiKeyBtn.addEventListener('click', function() {
+                        apiKeyInput.value = '';
+                        apiKeyInput.placeholder = 'API key will be removed on save';
+                        document.getElementById('clearApiKey').value = 'true';
+                    });
                 }
 
                 // Step 6: enable Bootstrap popover for the tool-calling explanation

--- a/src/test/java/org/remus/giteabot/admin/AiIntegrationControllerTest.java
+++ b/src/test/java/org/remus/giteabot/admin/AiIntegrationControllerTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -88,11 +89,34 @@ class AiIntegrationControllerTest {
                 .andExpect(redirectedUrl("/ai-integrations"));
 
         verify(aiIntegrationService).save(argThat(integration ->
-                "Google AI".equals(integration.getName())
-                        && "google".equals(integration.getProviderType())
-                        && "https://generativelanguage.googleapis.com".equals(integration.getApiUrl())
-                        && "gemini-key".equals(integration.getApiKey())
-                        && "gemini-2.5-flash".equals(integration.getModel())
-        ));
+                        "Google AI".equals(integration.getName())
+                                && "google".equals(integration.getProviderType())
+                                && "https://generativelanguage.googleapis.com".equals(integration.getApiUrl())
+                                && "gemini-key".equals(integration.getApiKey())
+                                && "gemini-2.5-flash".equals(integration.getModel())
+                ),
+                eq(false));
+    }
+
+    @Test
+    void save_blankApiKey_keepsKeyOutOfEntityAndForwardsClearFlag() throws Exception {
+        mockMvc.perform(post("/ai-integrations/save")
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf())
+                        .param("id", "7")
+                        .param("name", "Google AI")
+                        .param("providerType", "google")
+                        .param("apiUrl", "https://generativelanguage.googleapis.com")
+                        .param("apiKey", "")
+                        .param("clearApiKey", "true")
+                        .param("model", "gemini-2.5-flash"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/ai-integrations"));
+
+        // The kept ciphertext must never travel through the controller into
+        // save(), where it would be encrypted a second time and corrupt the key.
+        verify(aiIntegrationService).save(argThat(integration ->
+                        "".equals(integration.getApiKey()) || integration.getApiKey() == null),
+                eq(true));
     }
 }

--- a/src/test/java/org/remus/giteabot/admin/AiIntegrationServiceTest.java
+++ b/src/test/java/org/remus/giteabot/admin/AiIntegrationServiceTest.java
@@ -6,6 +6,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -45,6 +47,36 @@ class AiIntegrationServiceTest {
 
         assertEquals("encrypted-value", result.getApiKey());
         verify(encryptionService).encrypt("any-api-key");
+    }
+
+    @Test
+    void save_blankApiKeyOnUpdate_keepsStoredKeyWithoutReEncrypting() {
+        AiIntegration integration = new AiIntegration();
+        integration.setId(7L);
+        integration.setApiKey("");
+        AiIntegration existing = new AiIntegration();
+        existing.setApiKey("stored-encrypted-key");
+        when(aiIntegrationRepository.findById(7L)).thenReturn(Optional.of(existing));
+        when(aiIntegrationRepository.save(any(AiIntegration.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AiIntegration result = aiIntegrationService.save(integration);
+
+        assertEquals("stored-encrypted-key", result.getApiKey());
+        verify(encryptionService, never()).encrypt(anyString());
+    }
+
+    @Test
+    void save_clearApiKey_removesStoredKey() {
+        AiIntegration integration = new AiIntegration();
+        integration.setId(7L);
+        integration.setApiKey("");
+        when(aiIntegrationRepository.save(any(AiIntegration.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        AiIntegration result = aiIntegrationService.save(integration, true);
+
+        assertNull(result.getApiKey());
+        verify(aiIntegrationRepository, never()).findById(anyLong());
+        verify(encryptionService, never()).encrypt(anyString());
     }
 
     @Test


### PR DESCRIPTION
## What was done and why?

Editing an AI integration (e.g. changing the model) silently corrupted the stored API key. The controller kept the existing **encrypted** key when the key field was left blank and passed it back into `AiIntegrationService.save()`, which encrypted it a second time. The double-encrypted value no longer decrypts to the real key, so every provider request went out with a garbage bearer token and was rejected with **401 Missing Authentication header** (issue #343).

### Changes

- `AiIntegrationService.save()` now owns the keep-existing decision (same pattern as `BotService` for the webhook signing secret):
  - blank key input → the stored ciphertext is kept **as-is** (no re-encryption),
  - non-blank input → the freshly provided plaintext key is encrypted,
  - explicit `clearApiKey` flag → the key is removed.
- `AiIntegrationController` no longer copies the stored ciphertext into the entity before saving; it only overrides the key when a new one was entered and forwards the clear flag.
- The AI integration edit form gets a **Clear** button next to the API key field (same outline styling as the model Select button) that sets the clear flag, mirroring the webhook signing secret UI.
- Regression tests: `AiIntegrationServiceTest` (kept ciphertext is never re-encrypted, clear removes the key) and `AiIntegrationControllerTest` (kept ciphertext never travels through the controller).

### AI Usage
Implemented using Deepseek V4 Pro 0813 and opencode

### Note

Keys that were already corrupted by double-encryption cannot be recovered automatically. Operators re-enter the key once via the edit form after this fix.

Closes #343