### PR TITLE
fix(ai): report token-budget exhaustion instead of generic empty response

### DIFF
--- a/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
+++ b/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
@@ -261,10 +261,10 @@ public class OpenAiClient extends AbstractAiClient {
             String finishReason = firstChoice != null ? firstChoice.getFinishReason() : null;
             log.warn("Empty response from OpenAI API (finish_reason={})", finishReason);
             if ("length".equals(finishReason)) {
-                return "Unable to generate " + context
-                        + " - the model used its entire token budget without producing visible output"
-                        + " (finish_reason=length; typical for reasoning models)."
-                        + " Increase the max tokens setting of this AI integration.";
+                return """
+                        Unable to generate %s - the model used its entire token budget without producing visible output \
+                        (finish_reason=length; typical for reasoning models). \
+                        Increase the max tokens setting of this AI integration.""".formatted(context);
             }
             return "Unable to generate " + context + " - empty response from AI.";
         }

--- a/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
+++ b/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
@@ -247,21 +247,29 @@ public class OpenAiClient extends AbstractAiClient {
                 .body(OpenAiResponse.class);
     }
 
-    private String extractText(OpenAiRequest request, OpenAiResponse response, String context) {
+    String extractText(OpenAiRequest request, OpenAiResponse response, String context) {
         if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
             log.warn("Empty response from OpenAI API");
             return "Unable to generate " + context + " - empty response from AI.";
         }
 
         OpenAiResponse.Choice firstChoice = response.getChoices().getFirst();
-        if (firstChoice == null
-                || firstChoice.getMessage() == null
-                || firstChoice.getMessage().getContent() == null) {
-            log.warn("Empty response from OpenAI API");
+        String content = firstChoice != null && firstChoice.getMessage() != null
+                ? firstChoice.getMessage().getContent()
+                : null;
+        if (content == null || content.isBlank()) {
+            String finishReason = firstChoice != null ? firstChoice.getFinishReason() : null;
+            log.warn("Empty response from OpenAI API (finish_reason={})", finishReason);
+            if ("length".equals(finishReason)) {
+                return "Unable to generate " + context
+                        + " - the model used its entire token budget without producing visible output"
+                        + " (finish_reason=length; typical for reasoning models)."
+                        + " Increase the max tokens setting of this AI integration.";
+            }
             return "Unable to generate " + context + " - empty response from AI.";
         }
 
-        String result = firstChoice.getMessage().getContent();
+        String result = content;
         if (response.getUsage() != null) {
             log.info("OpenAI {} response: {} prompt tokens, {} completion tokens",
                     context,

--- a/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
+++ b/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
@@ -117,9 +117,10 @@ class OpenAiClientTest {
     }
 
     private OpenAiRequest reviewRequest() {
+        // Only forwarded to usage reporting; extractText never reads it.
         return OpenAiRequest.builder()
-                .model("openrouter/deepseek")
-                .maxTokens(4096)
+                .model("test-model")
+                .maxTokens(1024)
                 .build();
     }
 

--- a/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
+++ b/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
@@ -73,4 +73,69 @@ class OpenAiClientTest {
         assertFalse(client.supportsNativeTools());
     }
 
+    @Test
+    void extractText_explainsTokenBudget_whenFinishReasonIsLength() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice(null, "length"));
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("finish_reason=length"));
+        assertTrue(result.contains("max tokens"));
+        assertFalse(result.contains("empty response from AI"));
+    }
+
+    @Test
+    void extractText_explainsTokenBudget_whenContentIsBlankAndFinishReasonIsLength() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice("", "length"));
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("finish_reason=length"));
+    }
+
+    @Test
+    void extractText_keepsGenericMessage_whenNoLengthFinishReason() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice(null, "stop"));
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("empty response from AI"));
+        assertFalse(result.contains("finish_reason=length"));
+    }
+
+    @Test
+    void extractText_returnsContent_whenPresent() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice("The review looks good.", "stop"));
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("The review looks good."));
+    }
+
+    private OpenAiRequest reviewRequest() {
+        return OpenAiRequest.builder()
+                .model("openrouter/deepseek")
+                .maxTokens(4096)
+                .build();
+    }
+
+    private OpenAiResponse responseWith(OpenAiResponse.Choice... choices) {
+        OpenAiResponse response = new OpenAiResponse();
+        response.setChoices(java.util.Arrays.asList(choices));
+        return response;
+    }
+
+    private OpenAiResponse.Choice choice(String content, String finishReason) {
+        OpenAiResponse.Choice choice = new OpenAiResponse.Choice();
+        OpenAiResponse.Message message = new OpenAiResponse.Message();
+        message.setContent(content);
+        choice.setMessage(message);
+        choice.setFinishReason(finishReason);
+        return choice;
+    }
+
 }


### PR DESCRIPTION
## What has been done?

When an OpenAI-compatible API returns a choice without visible content (`message.content` null or blank) and `finish_reason=length`, `OpenAiClient.extractText` now produces an actionable message instead of the generic "empty response from AI":

> Unable to generate review - the model used its entire token budget without producing visible output (finish_reason=length; typical for reasoning models). Increase the max tokens setting of this AI integration.

Additionally:

- Blank content is now treated as empty. Previously it passed through and produced an empty review/comment body.
- The finish reason is included in the warning log line for easier diagnosis.

## Why?

Reasoning models (e.g. DeepSeek thinking variants served through OpenRouter) spend their completion budget on hidden reasoning tokens before producing visible output. When that budget is exhausted, `content` comes back empty and users only saw "Unable to generate review - empty response from AI.", which gives no hint about the actual cause or fix. The new message names the real problem and points at the max tokens setting of the AI integration.

## What has been tested?

- 4 new unit tests in `OpenAiClientTest`: budget-hint for null content + `finish_reason=length`, budget-hint for blank content + `length`, generic message retained for other finish reasons, and the happy path returning content.
- Full Maven suite green in Docker (Java 21): 1538 tests, 0 failures.

## How AI was used?

Diagnosis of the failure mode (root-cause analysis against the codebase and OpenRouter reasoning-token behavior) and implementation were done with OpenCode (model: ox-alpha); all changes were reviewed and verified by a human.
