### PR TITLE
feat(ui): add reusable CodeMirror 6 JSON editor with Prettier formatting

### DIFF
--- a/src/main/resources/static/js/json-editor.js
+++ b/src/main/resources/static/js/json-editor.js
@@ -11,11 +11,12 @@
  * so that standard form submission continues to work.
  */
 
-import { EditorView, basicSetup } from "https://esm.sh/codemirror@6.0.1";
-import { json, jsonParseLinter } from "https://esm.sh/@codemirror/lang-json@6.0.1";
-import { linter, lintGutter } from "https://esm.sh/@codemirror/lint@6.8.1";
-import { oneDark } from "https://esm.sh/@codemirror/theme-one-dark@6.1.2";
-import { placeholder as cmPlaceholder } from "https://esm.sh/@codemirror/view@6.33.0";
+import { EditorView, basicSetup } from "https://esm.sh/codemirror@6.0.1?deps=@codemirror/state@6.4.1";
+import { Compartment } from "https://esm.sh/@codemirror/state@6.4.1";
+import { json, jsonParseLinter } from "https://esm.sh/@codemirror/lang-json@6.0.1?deps=@codemirror/state@6.4.1";
+import { linter, lintGutter } from "https://esm.sh/@codemirror/lint@6.8.1?deps=@codemirror/state@6.4.1";
+import { oneDark } from "https://esm.sh/@codemirror/theme-one-dark@6.1.2?deps=@codemirror/state@6.4.1";
+import { placeholder as cmPlaceholder } from "https://esm.sh/@codemirror/view@6.33.0?deps=@codemirror/state@6.4.1";
 import * as prettier from "https://esm.sh/prettier@3.3.3/standalone";
 import * as estreePlugin from "https://esm.sh/prettier@3.3.3/plugins/estree";
 import * as babelPlugin from "https://esm.sh/prettier@3.3.3/plugins/babel";
@@ -34,6 +35,10 @@ function jsonLinter() {
 
 function isDarkMode() {
     return document.documentElement.getAttribute('data-bs-theme') === 'dark';
+}
+
+function themeExtension() {
+    return isDarkMode() ? oneDark : [];
 }
 
 async function formatJson(text) {
@@ -101,15 +106,20 @@ export function initJsonEditor(textarea, options) {
         extensions.push(cmPlaceholder(textarea.placeholder));
     }
 
-    if (isDarkMode()) {
-        extensions.push(oneDark);
-    }
+    const themeCompartment = new Compartment();
+    extensions.push(themeCompartment.of(themeExtension()));
 
     const view = new EditorView({
         doc: textarea.value,
         extensions: extensions,
         parent: wrapper
     });
+
+    // Reconfigure the editor theme when the app theme is toggled at runtime.
+    const applyTheme = () => {
+        view.dispatch({ effects: themeCompartment.reconfigure(themeExtension()) });
+    };
+    document.addEventListener('themeChanged', applyTheme);
 
     // Hide the original textarea but keep it in the DOM for form submission.
     textarea.classList.add('d-none');

--- a/src/main/resources/static/js/json-editor.js
+++ b/src/main/resources/static/js/json-editor.js
@@ -1,0 +1,160 @@
+/**
+ * Reusable JSON editor built on CodeMirror 6 with Prettier formatting.
+ *
+ * Usage:
+ *   import { initJsonEditor } from '/js/json-editor.js';
+ *   initJsonEditor(document.getElementById('jsonContent'), {
+ *       formatButton: document.getElementById('jsonContentFormatBtn')
+ *   });
+ *
+ * The original <textarea> remains in the DOM (hidden) and is kept in sync
+ * so that standard form submission continues to work.
+ */
+
+import { EditorView, basicSetup } from "https://esm.sh/codemirror@6.0.1";
+import { json, jsonParseLinter } from "https://esm.sh/@codemirror/lang-json@6.0.1";
+import { linter, lintGutter } from "https://esm.sh/@codemirror/lint@6.8.1";
+import { oneDark } from "https://esm.sh/@codemirror/theme-one-dark@6.1.2";
+import { placeholder as cmPlaceholder } from "https://esm.sh/@codemirror/view@6.33.0";
+import * as prettier from "https://esm.sh/prettier@3.3.3/standalone";
+import * as estreePlugin from "https://esm.sh/prettier@3.3.3/plugins/estree";
+import * as babelPlugin from "https://esm.sh/prettier@3.3.3/plugins/babel";
+
+const PRETTIER_PLUGINS = [estreePlugin, babelPlugin];
+
+function jsonLinter() {
+    return (view) => {
+        const text = view.state.doc.toString();
+        if (text.trim().length === 0) {
+            return [];
+        }
+        return jsonParseLinter()(view);
+    };
+}
+
+function isDarkMode() {
+    return document.documentElement.getAttribute('data-bs-theme') === 'dark';
+}
+
+async function formatJson(text) {
+    return prettier.format(text, {
+        parser: "json",
+        plugins: PRETTIER_PLUGINS,
+        printWidth: 80,
+        tabWidth: 2,
+        useTabs: false
+    });
+}
+
+/**
+ * @param {HTMLTextAreaElement} textarea - the textarea to enhance
+ * @param {Object} [options]
+ * @param {HTMLElement} [options.formatButton] - button that triggers pretty-print
+ * @param {string} [options.minHeight='120px'] - minimum editor height
+ * @param {string} [options.maxHeight='600px'] - maximum editor height before scrolling
+ * @returns {EditorView|null} the CodeMirror view, or null if initialization failed
+ */
+export function initJsonEditor(textarea, options) {
+    if (!textarea || textarea.tagName !== 'TEXTAREA') {
+        console.error('initJsonEditor: expected a textarea element');
+        return null;
+    }
+
+    const opts = options || {};
+    const formatButton = opts.formatButton || null;
+    const minHeight = opts.minHeight || '120px';
+    const maxHeight = opts.maxHeight || '600px';
+
+    // Wrap the editor so the hidden textarea stays close to its original position.
+    const wrapper = document.createElement('div');
+    wrapper.id = textarea.id ? (textarea.id + '-editor') : '';
+    wrapper.className = 'cm-editor-wrapper position-relative';
+    textarea.parentNode.insertBefore(wrapper, textarea);
+
+    const extensions = [
+        basicSetup,
+        json(),
+        linter(jsonLinter()),
+        lintGutter(),
+        EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+                textarea.value = update.state.doc.toString();
+            }
+        }),
+        EditorView.theme({
+            "&": {
+                fontSize: "14px",
+                border: "1px solid var(--bs-border-color)",
+                borderRadius: "var(--bs-border-radius)"
+            },
+            ".cm-scroller": {
+                minHeight: minHeight,
+                maxHeight: maxHeight
+            },
+            ".cm-gutters": {
+                borderRadius: "var(--bs-border-radius) 0 0 var(--bs-border-radius)"
+            }
+        })
+    ];
+
+    if (textarea.placeholder) {
+        extensions.push(cmPlaceholder(textarea.placeholder));
+    }
+
+    if (isDarkMode()) {
+        extensions.push(oneDark);
+    }
+
+    const view = new EditorView({
+        doc: textarea.value,
+        extensions: extensions,
+        parent: wrapper
+    });
+
+    // Hide the original textarea but keep it in the DOM for form submission.
+    textarea.classList.add('d-none');
+
+    // Keep CodeMirror in sync if something external mutates the textarea.
+    textarea.addEventListener('input', () => {
+        const current = view.state.doc.toString();
+        if (current !== textarea.value) {
+            view.dispatch({
+                changes: { from: 0, to: current.length, insert: textarea.value }
+            });
+        }
+    });
+
+    async function doFormat() {
+        const current = view.state.doc.toString().trim();
+        if (!current) {
+            return;
+        }
+        try {
+            JSON.parse(current); // cheap validity check before invoking Prettier
+            const formatted = await formatJson(current);
+            view.dispatch({
+                changes: { from: 0, to: view.state.doc.length, insert: formatted }
+            });
+        } catch (err) {
+            // Lint gutter already highlights the parse error; no need to spam the console.
+            if (err instanceof SyntaxError) {
+                return;
+            }
+            console.warn('JSON format failed', err);
+        }
+    }
+
+    if (formatButton) {
+        formatButton.addEventListener('click', doFormat);
+    }
+
+    // Shift+Alt+F triggers pretty-print inside the editor.
+    view.dom.addEventListener('keydown', (event) => {
+        if (event.shiftKey && event.altKey && event.key === 'F') {
+            event.preventDefault();
+            doFormat();
+        }
+    });
+
+    return view;
+}

--- a/src/main/resources/static/js/theme-init.js
+++ b/src/main/resources/static/js/theme-init.js
@@ -34,6 +34,7 @@
             document.documentElement.style.colorScheme = theme;
         }
         document.documentElement.setAttribute('data-bs-theme', actualTheme);
+        document.dispatchEvent(new CustomEvent('themeChanged', { detail: { theme: actualTheme } }));
         updateUI(theme, actualTheme);
     };
 

--- a/src/main/resources/templates/event-hooks/form.html
+++ b/src/main/resources/templates/event-hooks/form.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layout :: layout(#{page.eventHook.title}, ~{::pageContent})}">
+      th:replace="~{layout :: layoutWithExtras(#{page.eventHook.title}, ~{::pageContent}, ~{::extraHead}, ~{::extraScripts})}">
+<head>
+    <th:block th:fragment="extraHead">
+        <!-- CodeMirror 6 injects its styles via JS; no extra CSS link required. -->
+    </th:block>
+</head>
 <body>
     <div th:fragment="pageContent">
 
@@ -48,8 +53,13 @@
             </div>
 
             <div class="mb-3">
-                <label class="form-label" th:text="#{label.customHeaders}">Custom headers (JSON object, optional)</label>
-                <textarea class="form-control font-monospace" rows="3" name="plainCustomHeaders"
+                <div class="d-flex justify-content-between align-items-center">
+                    <label for="plainCustomHeaders" class="form-label" th:text="#{label.customHeaders}">Custom headers (JSON object, optional)</label>
+                    <button type="button" id="plainCustomHeadersFormatBtn" class="btn btn-sm btn-outline-secondary">
+                        <i class="bi bi-code-slash"></i> Format JSON
+                    </button>
+                </div>
+                <textarea class="form-control font-monospace" rows="3" name="plainCustomHeaders" id="plainCustomHeaders"
                           th:placeholder="${endpoint.customHeaders != null} ? #{placeholder.configuredKeep} : '{ &quot;X-Source&quot;: &quot;ai-git-bot&quot; }'"></textarea>
                 <div class="form-text" th:text="#{help.hook.customHeaders}">Sent with every delivery. Must be a single JSON object. Stored
                     encrypted; leave blank on edit to keep the current value.</div>
@@ -133,5 +143,14 @@
         </form>
 
     </div>
+
+    <th:block th:fragment="extraScripts">
+        <script type="module">
+            import { initJsonEditor } from /*[[@{/js/json-editor.js}]]*/ '/js/json-editor.js';
+            initJsonEditor(document.getElementById('plainCustomHeaders'), {
+                formatButton: document.getElementById('plainCustomHeadersFormatBtn')
+            });
+        </script>
+    </th:block>
 </body>
 </html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
+<th:block th:fragment="layout(title, content)"
+          th:replace="~{::layoutWithExtras(${title}, ${content}, null, null)}"></th:block>
 <html lang="en" xmlns:th="http://www.thymeleaf.org"
-      th:fragment="layout(title, content)">
+      th:fragment="layoutWithExtras(title, content, extraHead, extraScripts)">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -9,6 +11,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"/>
     <link rel="icon" type="image/png" th:href="@{/images/favicon.png}"/>
     <script th:src="@{/js/theme-init.js}"></script>
+    <th:block th:if="${extraHead != null}">
+        <th:block th:replace="${extraHead}"></th:block>
+    </th:block>
 </head>
 <body>
 
@@ -117,6 +122,10 @@
         window.giteabotTourDismiss = /*[[#{tour.dismiss}]]*/ 'Dismiss';
     </script>
     <script th:src="@{/js/balloon-help.js}"></script>
+
+    <th:block th:if="${extraScripts != null}">
+        <th:block th:replace="${extraScripts}"></th:block>
+    </th:block>
 
 </body>
 </html>

--- a/src/main/resources/templates/system-settings/mcp-form.html
+++ b/src/main/resources/templates/system-settings/mcp-form.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org"
-      th:replace="~{layout :: layout(${mcpConfiguration.id != null ? #messages.msg('page.mcpConfiguration.editTitle') : #messages.msg('page.mcpConfiguration.newTitle')}, ~{::pageContent})}">
+      th:replace="~{layout :: layoutWithExtras(${mcpConfiguration.id != null ? #messages.msg('page.mcpConfiguration.editTitle') : #messages.msg('page.mcpConfiguration.newTitle')}, ~{::pageContent}, ~{::extraHead}, ~{::extraScripts})}">
+<head>
+    <th:block th:fragment="extraHead">
+        <!-- CodeMirror 6 injects its styles via JS; no extra CSS link required. -->
+    </th:block>
+</head>
 <body>
     <div th:fragment="pageContent">
 
@@ -30,7 +35,12 @@
                         </div>
 
                         <div class="col-12">
-                            <label for="jsonContent" class="form-label" th:text="#{label.mcpJson}">MCP JSON</label>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <label for="jsonContent" class="form-label" th:text="#{label.mcpJson}">MCP JSON</label>
+                                <button type="button" id="jsonContentFormatBtn" class="btn btn-sm btn-outline-secondary">
+                                    <i class="bi bi-code-slash"></i> Format JSON
+                                </button>
+                            </div>
                             <textarea class="form-control font-monospace" id="jsonContent" th:field="*{jsonContent}"
                                       rows="14" required
                                       placeholder='{"name":"github","type":"url","url":"https://example.com/mcp"}'></textarea>
@@ -53,5 +63,14 @@
         </div>
 
     </div>
+
+    <th:block th:fragment="extraScripts">
+        <script type="module">
+            import { initJsonEditor } from /*[[@{/js/json-editor.js}]]*/ '/js/json-editor.js';
+            initJsonEditor(document.getElementById('jsonContent'), {
+                formatButton: document.getElementById('jsonContentFormatBtn')
+            });
+        </script>
+    </th:block>
 </body>
 </html>

--- a/tests/e2e/pr-326/create-mcp-configuration-and-select-tools.spec.ts
+++ b/tests/e2e/pr-326/create-mcp-configuration-and-select-tools.spec.ts
@@ -54,9 +54,10 @@ test('admin can create a new MCP configuration and select tools', async ({ page 
   await nameInput.fill(uniqueName);
 
   // Step 4: Fill the MCP JSON multi-form field (textarea#jsonContent).
-  const jsonTextarea = page.locator('#jsonContent').first();
-  await jsonTextarea.waitFor({ state: 'visible', timeout: 30_000 });
-  await jsonTextarea.fill(jsonContent);
+  const jsonEditor = page.locator('#jsonContent-editor .cm-content').first();
+  await jsonEditor.waitFor({ state: 'visible', timeout: 30_000 });
+  await jsonEditor.click();
+  await jsonEditor.fill(jsonContent);
 
   // Step 5: Click the "Save and select tools" button.
   const saveAndSelectBtn = page.locator('button:has-text("Save and select tools")').first();

--- a/tests/e2e/pr-326/preserve-selected-tools-across-edit.spec.ts
+++ b/tests/e2e/pr-326/preserve-selected-tools-across-edit.spec.ts
@@ -54,9 +54,10 @@ test('selected tools persist when re-opening tool selection for an MCP configura
   await nameInput.fill(uniqueName);
 
   // Step 4: Fill the MCP JSON multi-form field.
-  const jsonTextarea = page.locator('#jsonContent').first();
-  await jsonTextarea.waitFor({ state: 'visible', timeout: 30_000 });
-  await jsonTextarea.fill(jsonContent);
+  const jsonEditor = page.locator('#jsonContent-editor .cm-content').first();
+  await jsonEditor.waitFor({ state: 'visible', timeout: 30_000 });
+  await jsonEditor.click();
+  await jsonEditor.fill(jsonContent);
 
   // Step 5: Click "Save and select tools".
   const saveAndSelectBtn = page.locator('button:has-text("Save and select tools")').first();


### PR DESCRIPTION
- Add src/main/resources/static/js/json-editor.js with JSON linting,
  dark-mode awareness, and a "Format JSON" button.
- Extend layout.html with layoutWithExtras to inject per-page head and
  script fragments.
- Wire the editor into system-settings/mcp-form.html and
  event-hooks/form.html.
- Update e2e tests to fill the CodeMirror .cm-content element.

<img width="1191" height="548" alt="image" src="https://github.com/user-attachments/assets/5e4fdd98-41a7-44ef-b5d3-1bcd47e2f2e8" />
