### PR TITLE
feat(ai): surface provider errors from OpenAI API responses

### DIFF
--- a/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
+++ b/src/main/java/org/remus/giteabot/ai/openai/OpenAiClient.java
@@ -257,8 +257,18 @@ public class OpenAiClient extends AbstractAiClient {
         String content = firstChoice != null && firstChoice.getMessage() != null
                 ? firstChoice.getMessage().getContent()
                 : null;
+        String finishReason = firstChoice != null ? firstChoice.getFinishReason() : null;
+        if ("error".equals(finishReason)) {
+            OpenAiResponse.Error error = firstChoice.getError() != null
+                    ? firstChoice.getError()
+                    : response.getError();
+            String errorMessage = error != null && error.getMessage() != null
+                    ? error.getMessage()
+                    : "unknown provider error";
+            log.warn("OpenAI API returned finish_reason=error: {}", errorMessage);
+            return "Unable to generate %s - provider returned an error (%s).".formatted(context, errorMessage);
+        }
         if (content == null || content.isBlank()) {
-            String finishReason = firstChoice != null ? firstChoice.getFinishReason() : null;
             log.warn("Empty response from OpenAI API (finish_reason={})", finishReason);
             if ("length".equals(finishReason)) {
                 return """
@@ -269,7 +279,6 @@ public class OpenAiClient extends AbstractAiClient {
             return "Unable to generate " + context + " - empty response from AI.";
         }
 
-        String result = content;
         if (response.getUsage() != null) {
             log.info("OpenAI {} response: {} prompt tokens, {} completion tokens",
                     context,
@@ -279,7 +288,7 @@ public class OpenAiClient extends AbstractAiClient {
                     response.getUsage().getCompletionTokens(), 0L, 0L, request, response);
         }
 
-        return result;
+        return content;
     }
 }
 

--- a/src/main/java/org/remus/giteabot/ai/openai/OpenAiResponse.java
+++ b/src/main/java/org/remus/giteabot/ai/openai/OpenAiResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -17,6 +18,8 @@ public class OpenAiResponse {
     private List<Choice> choices;
     private Usage usage;
 
+    private Error error;
+
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Choice {
@@ -25,6 +28,8 @@ public class OpenAiResponse {
 
         @JsonProperty("finish_reason")
         private String finishReason;
+
+        private Error error;
     }
 
     @Data
@@ -65,5 +70,18 @@ public class OpenAiResponse {
 
         @JsonProperty("total_tokens")
         private int totalTokens;
+    }
+
+    /**
+     * OpenRouter-specific error object describing a provider-side failure.
+     * Kept intentionally loose (metadata is a map) so arbitrary provider
+     * details are preserved in audit logs without requiring a typed model.
+     */
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Error {
+        private int code;
+        private String message;
+        private Map<String, Object> metadata;
     }
 }

--- a/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
+++ b/src/test/java/org/remus/giteabot/ai/openai/OpenAiClientTest.java
@@ -116,6 +116,60 @@ class OpenAiClientTest {
         assertTrue(result.contains("The review looks good."));
     }
 
+    @Test
+    void extractText_reportsProviderError_whenFinishReasonIsError() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice(null, "error"));
+        OpenAiResponse.Error error = new OpenAiResponse.Error();
+        error.setCode(502);
+        error.setMessage("Provider disconnected mid-stream");
+        response.getChoices().getFirst().setError(error);
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("provider returned an error"));
+        assertTrue(result.contains("Provider disconnected mid-stream"));
+        assertFalse(result.contains("empty response from AI"));
+    }
+
+    @Test
+    void extractText_fallsBackToResponseError_whenChoiceErrorMissing() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice(null, "error"));
+        OpenAiResponse.Error error = new OpenAiResponse.Error();
+        error.setMessage("Rate limit exceeded");
+        response.setError(error);
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("Rate limit exceeded"));
+    }
+
+    @Test
+    void extractText_usesUnknownProviderError_whenErrorDetailsMissing() {
+        OpenAiClient client = createClient();
+        OpenAiResponse response = responseWith(choice(null, "error"));
+
+        String result = client.extractText(reviewRequest(), response, "review");
+
+        assertTrue(result.contains("unknown provider error"));
+    }
+
+    @Test
+    void errorField_isSerializedInRawResponseAuditPayload() {
+        OpenAiResponse response = responseWith(choice(null, "error"));
+        OpenAiResponse.Error error = new OpenAiResponse.Error();
+        error.setCode(429);
+        error.setMessage("Rate limit exceeded");
+        response.getChoices().getFirst().setError(error);
+
+        String json = org.remus.giteabot.agent.shared.AgentJackson.mapper().writeValueAsString(response);
+
+        assertTrue(json.contains("\"error\""));
+        assertTrue(json.contains("\"code\":429"));
+        assertTrue(json.contains("Rate limit exceeded"));
+    }
+
     private OpenAiRequest reviewRequest() {
         // Only forwarded to usage reporting; extractText never reads it.
         return OpenAiRequest.builder()


### PR DESCRIPTION
Add an OpenRouter-compatible Error type to OpenAiResponse with code, message, and metadata fields. Check for finish_reason=error before falling through to the empty-response path, extracting the provider error message (choice-level → response-level → "unknown provider error") and surfacing it in a user-friendly reply. Add unit tests for the error, fallback, and missing-error cases, plus a JSON serialization check.